### PR TITLE
feat: implement default field ClientOptions

### DIFF
--- a/scw/client.go
+++ b/scw/client.go
@@ -68,6 +68,18 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	}, nil
 }
 
+func (c *Client) GetDefaultOrganizationId() string {
+	return c.defaultOrganizationId
+}
+
+func (c *Client) GetDefaultRegion() Region {
+	return c.defaultRegion
+}
+
+func (c *Client) GetDefaultZone() Zone {
+	return c.defaultZone
+}
+
 func defaultOptions() []ClientOption {
 	return []ClientOption{
 		WithApiUrl("https://api.scaleway.com"),

--- a/scw/client.go
+++ b/scw/client.go
@@ -41,15 +41,15 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	}
 
 	// dial the API
-	if s.HttpClient == nil {
-		s.HttpClient = newHttpClient()
+	if s.httpClient == nil {
+		s.httpClient = newHttpClient()
 	}
 
 	// insecure mode
-	if s.Insecure {
-		clientTransport, ok := s.HttpClient.Transport.(*http.Transport)
+	if s.insecure {
+		clientTransport, ok := s.httpClient.Transport.(*http.Transport)
 		if !ok {
-			return nil, fmt.Errorf("cannot use insecure mode with HTTP client of type %T", s.HttpClient.Transport)
+			return nil, fmt.Errorf("cannot use insecure mode with HTTP client of type %T", s.httpClient.Transport)
 		}
 		if clientTransport.TLSClientConfig == nil {
 			clientTransport.TLSClientConfig = &tls.Config{}
@@ -58,13 +58,13 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	}
 
 	return &Client{
-		auth:                  s.Token,
-		httpClient:            s.HttpClient,
-		apiUrl:                s.ApiUrl,
-		userAgent:             s.UserAgent,
-		defaultOrganizationId: s.DefaultOrganizationId,
-		defaultRegion:         s.DefaultRegion,
-		defaultZone:           s.DefaultZone,
+		auth:                  s.token,
+		httpClient:            s.httpClient,
+		apiUrl:                s.apiUrl,
+		userAgent:             s.userAgent,
+		defaultOrganizationId: s.defaultOrganizationId,
+		defaultRegion:         s.defaultRegion,
+		defaultZone:           s.defaultZone,
 	}, nil
 }
 

--- a/scw/client.go
+++ b/scw/client.go
@@ -15,10 +15,13 @@ import (
 // This client should be passed in the `NewApi` functions whenever an API instance is created.
 // Creating a Client is done with the `NewClient` function.
 type Client struct {
-	httpClient *http.Client
-	auth       auth.Auth
-	baseUrl    string
-	userAgent  string
+	httpClient            *http.Client
+	auth                  auth.Auth
+	baseUrl               string
+	userAgent             string
+	defaultOrganizationId string
+	defaultRegion         Region
+	defaultZone           Zone
 }
 
 // NewClient instantiates a new Client object.
@@ -55,10 +58,13 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	}
 
 	return &Client{
-		auth:       s.Token,
-		httpClient: s.HttpClient,
-		baseUrl:    s.Url,
-		userAgent:  s.UserAgent,
+		auth:                  s.Token,
+		httpClient:            s.HttpClient,
+		baseUrl:               s.Url,
+		userAgent:             s.UserAgent,
+		defaultOrganizationId: s.DefaultOrganizationId,
+		defaultRegion:         s.DefaultRegion,
+		defaultZone:           s.DefaultZone,
 	}, nil
 }
 

--- a/scw/client.go
+++ b/scw/client.go
@@ -17,7 +17,7 @@ import (
 type Client struct {
 	httpClient            *http.Client
 	auth                  auth.Auth
-	baseUrl               string
+	apiUrl                string
 	userAgent             string
 	defaultOrganizationId string
 	defaultRegion         Region
@@ -60,7 +60,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	return &Client{
 		auth:                  s.Token,
 		httpClient:            s.HttpClient,
-		baseUrl:               s.Url,
+		apiUrl:                s.ApiUrl,
 		userAgent:             s.UserAgent,
 		defaultOrganizationId: s.DefaultOrganizationId,
 		defaultRegion:         s.DefaultRegion,
@@ -70,7 +70,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 
 func defaultOptions() []ClientOption {
 	return []ClientOption{
-		WithEndpoint("https://api.scaleway.com"),
+		WithApiUrl("https://api.scaleway.com"),
 		WithUserAgent(userAgent),
 	}
 }

--- a/scw/client_option.go
+++ b/scw/client_option.go
@@ -23,10 +23,10 @@ func WithAuth(accessKey, secretKey string) ClientOption {
 	}
 }
 
-// WithEndpoint client option overrides the endpoint URL of the Scaleway API to the given URL.
-func WithEndpoint(url string) ClientOption {
+// WithApiUrl client option overrides the API URL of the Scaleway API to the given URL.
+func WithApiUrl(apiUrl string) ClientOption {
 	return func(s *settings) {
-		s.Url = url
+		s.ApiUrl = apiUrl
 	}
 }
 

--- a/scw/client_option.go
+++ b/scw/client_option.go
@@ -12,42 +12,42 @@ type ClientOption func(*settings)
 // WithoutAuth client option sets the client token to an empty token.
 func WithoutAuth() ClientOption {
 	return func(s *settings) {
-		s.Token = auth.NewNoAuth()
+		s.token = auth.NewNoAuth()
 	}
 }
 
 // WithAuth client option sets the client access key and secret key.
 func WithAuth(accessKey, secretKey string) ClientOption {
 	return func(s *settings) {
-		s.Token = auth.NewToken(accessKey, secretKey)
+		s.token = auth.NewToken(accessKey, secretKey)
 	}
 }
 
 // WithApiUrl client option overrides the API URL of the Scaleway API to the given URL.
 func WithApiUrl(apiUrl string) ClientOption {
 	return func(s *settings) {
-		s.ApiUrl = apiUrl
+		s.apiUrl = apiUrl
 	}
 }
 
 // WithInsecure client option enables insecure transport on the client.
 func WithInsecure() ClientOption {
 	return func(s *settings) {
-		s.Insecure = true
+		s.insecure = true
 	}
 }
 
 // WithUserAgent client option overrides the default user agent of the SDK.
 func WithUserAgent(ua string) ClientOption {
 	return func(s *settings) {
-		s.UserAgent = ua
+		s.userAgent = ua
 	}
 }
 
 // WithHttpClient client option allows passing a custom http.Client which will be used for all requests.
 func WithHttpClient(httpClient *http.Client) ClientOption {
 	return func(s *settings) {
-		s.HttpClient = httpClient
+		s.httpClient = httpClient
 	}
 }
 
@@ -56,7 +56,7 @@ func WithHttpClient(httpClient *http.Client) ClientOption {
 // It will be used as the default value of the organization_id field in all requests made with this client.
 func WithDefaultOrganizationId(organizationId string) ClientOption {
 	return func(s *settings) {
-		s.DefaultOrganizationId = organizationId
+		s.defaultOrganizationId = organizationId
 	}
 }
 
@@ -65,7 +65,7 @@ func WithDefaultOrganizationId(organizationId string) ClientOption {
 // It will be used as the default value of the region field in all requests made with this client.
 func WithDefaultRegion(region Region) ClientOption {
 	return func(s *settings) {
-		s.DefaultRegion = region
+		s.defaultRegion = region
 	}
 }
 
@@ -74,6 +74,6 @@ func WithDefaultRegion(region Region) ClientOption {
 // It will be used as the default value of the zone field in all requests made with this client.
 func WithDefaultZone(zone Zone) ClientOption {
 	return func(s *settings) {
-		s.DefaultZone = zone
+		s.defaultZone = zone
 	}
 }

--- a/scw/client_option.go
+++ b/scw/client_option.go
@@ -44,9 +44,36 @@ func WithUserAgent(ua string) ClientOption {
 	}
 }
 
-// WithHttpClient client options allows passing a custom http.Client which will be used for all requests.
+// WithHttpClient client option allows passing a custom http.Client which will be used for all requests.
 func WithHttpClient(httpClient *http.Client) ClientOption {
 	return func(s *settings) {
 		s.HttpClient = httpClient
+	}
+}
+
+// WithDefaultOrganizationId client option sets the client default organization ID.
+//
+// It will be used as the default value of the organization_id field in all requests made with this client.
+func WithDefaultOrganizationId(organizationId string) ClientOption {
+	return func(s *settings) {
+		s.DefaultOrganizationId = organizationId
+	}
+}
+
+// WithDefaultRegion client option sets the client default region.
+//
+// It will be used as the default value of the region field in all requests made with this client.
+func WithDefaultRegion(region Region) ClientOption {
+	return func(s *settings) {
+		s.DefaultRegion = region
+	}
+}
+
+// WithDefaultZone client option sets the client default zone.
+//
+// It will be used as the default value of the zone field in all requests made with this client.
+func WithDefaultZone(zone Zone) ClientOption {
+	return func(s *settings) {
+		s.DefaultZone = zone
 	}
 }

--- a/scw/client_test.go
+++ b/scw/client_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	testEndpoint              = "https://api.example.com/"
-	defaultEndpoint           = "https://api.scaleway.com"
+	testApiUrl                = "https://api.example.com/"
+	defaultApiUrl             = "https://api.scaleway.com"
 	testAccessKey             = "some access key"
 	testSecretKey             = "some secret key"
 	testDefaultOrganizationId = "some default organization id"
@@ -28,7 +28,7 @@ func TestNewClientWithDefaults(t *testing.T) {
 	client, err := NewClient(options...)
 	testhelpers.Ok(t, err)
 
-	testhelpers.Equals(t, defaultEndpoint, client.baseUrl)
+	testhelpers.Equals(t, defaultApiUrl, client.apiUrl)
 	testhelpers.Equals(t, auth.NewNoAuth(), client.auth)
 
 }
@@ -38,7 +38,7 @@ func TestNewClientWithOptions(t *testing.T) {
 	someHTTPClient := &http.Client{}
 
 	options := []ClientOption{
-		WithEndpoint(testEndpoint),
+		WithApiUrl(testApiUrl),
 		WithAuth(testAccessKey, testSecretKey),
 		WithHttpClient(someHTTPClient),
 		WithDefaultOrganizationId(testDefaultOrganizationId),
@@ -49,7 +49,7 @@ func TestNewClientWithOptions(t *testing.T) {
 	client, err := NewClient(options...)
 	testhelpers.Ok(t, err)
 
-	testhelpers.Equals(t, testEndpoint, client.baseUrl)
+	testhelpers.Equals(t, testApiUrl, client.apiUrl)
 	testhelpers.Equals(t, auth.NewToken(testAccessKey, testSecretKey), client.auth)
 
 	testhelpers.Equals(t, someHTTPClient, client.httpClient)

--- a/scw/client_test.go
+++ b/scw/client_test.go
@@ -54,8 +54,8 @@ func TestNewClientWithOptions(t *testing.T) {
 
 	testhelpers.Equals(t, someHTTPClient, client.httpClient)
 
-	testhelpers.Equals(t, testDefaultOrganizationId, client.defaultOrganizationId)
-	testhelpers.Equals(t, testDefaultRegion, client.defaultRegion)
-	testhelpers.Equals(t, testDefaultZone, client.defaultZone)
+	testhelpers.Equals(t, testDefaultOrganizationId, client.GetDefaultOrganizationId())
+	testhelpers.Equals(t, testDefaultRegion, client.GetDefaultRegion())
+	testhelpers.Equals(t, testDefaultZone, client.GetDefaultZone())
 
 }

--- a/scw/client_test.go
+++ b/scw/client_test.go
@@ -9,10 +9,13 @@ import (
 )
 
 const (
-	testEndpoint    = "https://api.example.com/"
-	defaultEndpoint = "https://api.scaleway.com"
-	testAccessKey   = "some access key"
-	testSecretKey   = "some secret key"
+	testEndpoint              = "https://api.example.com/"
+	defaultEndpoint           = "https://api.scaleway.com"
+	testAccessKey             = "some access key"
+	testSecretKey             = "some secret key"
+	testDefaultOrganizationId = "some default organization id"
+	testDefaultRegion         = RegionFrPar
+	testDefaultZone           = ZoneFrPar1
 )
 
 func TestNewClientWithDefaults(t *testing.T) {
@@ -38,6 +41,9 @@ func TestNewClientWithOptions(t *testing.T) {
 		WithEndpoint(testEndpoint),
 		WithAuth(testAccessKey, testSecretKey),
 		WithHttpClient(someHTTPClient),
+		WithDefaultOrganizationId(testDefaultOrganizationId),
+		WithDefaultRegion(testDefaultRegion),
+		WithDefaultZone(testDefaultZone),
 	}
 
 	client, err := NewClient(options...)
@@ -47,5 +53,9 @@ func TestNewClientWithOptions(t *testing.T) {
 	testhelpers.Equals(t, auth.NewToken(testAccessKey, testSecretKey), client.auth)
 
 	testhelpers.Equals(t, someHTTPClient, client.httpClient)
+
+	testhelpers.Equals(t, testDefaultOrganizationId, client.defaultOrganizationId)
+	testhelpers.Equals(t, testDefaultRegion, client.defaultRegion)
+	testhelpers.Equals(t, testDefaultZone, client.defaultZone)
 
 }

--- a/scw/request.go
+++ b/scw/request.go
@@ -28,7 +28,7 @@ func (c *Client) Do(req *ScalewayRequest, opts ...RequestOption) (*http.Response
 	}
 
 	// build url
-	url, err := req.getURL(c.baseUrl)
+	url, err := req.getURL(c.apiUrl)
 	if err != nil {
 		return nil, err
 	}

--- a/scw/settings.go
+++ b/scw/settings.go
@@ -9,7 +9,7 @@ import (
 )
 
 type settings struct {
-	Url                   string
+	ApiUrl                string
 	Token                 auth.Auth
 	UserAgent             string
 	HttpClient            *http.Client
@@ -36,9 +36,9 @@ func (s *settings) validate() error {
 		return fmt.Errorf("no credential option provided")
 	}
 
-	_, err = url.Parse(s.Url)
+	_, err = url.Parse(s.ApiUrl)
 	if err != nil {
-		return fmt.Errorf("invalid url %s: %s", s.Url, err)
+		return fmt.Errorf("invalid url %s: %s", s.ApiUrl, err)
 	}
 
 	return nil

--- a/scw/settings.go
+++ b/scw/settings.go
@@ -9,12 +9,11 @@ import (
 )
 
 type settings struct {
-	Url        string
-	Token      auth.Auth
-	UserAgent  string
-	HttpClient *http.Client
-	Insecure   bool
-
+	Url                   string
+	Token                 auth.Auth
+	UserAgent             string
+	HttpClient            *http.Client
+	Insecure              bool
 	DefaultOrganizationId string
 	DefaultRegion         Region
 	DefaultZone           Zone

--- a/scw/settings.go
+++ b/scw/settings.go
@@ -9,12 +9,15 @@ import (
 )
 
 type settings struct {
-	Url           string
-	Token         auth.Auth
-	DefaultRegion string
-	UserAgent     string
-	HttpClient    *http.Client
-	Insecure      bool
+	Url        string
+	Token      auth.Auth
+	UserAgent  string
+	HttpClient *http.Client
+	Insecure   bool
+
+	DefaultOrganizationId string
+	DefaultRegion         Region
+	DefaultZone           Zone
 }
 
 func newSettings() *settings {

--- a/scw/settings.go
+++ b/scw/settings.go
@@ -9,14 +9,14 @@ import (
 )
 
 type settings struct {
-	ApiUrl                string
-	Token                 auth.Auth
-	UserAgent             string
-	HttpClient            *http.Client
-	Insecure              bool
-	DefaultOrganizationId string
-	DefaultRegion         Region
-	DefaultZone           Zone
+	apiUrl                string
+	token                 auth.Auth
+	userAgent             string
+	httpClient            *http.Client
+	insecure              bool
+	defaultOrganizationId string
+	defaultRegion         Region
+	defaultZone           Zone
 }
 
 func newSettings() *settings {
@@ -32,13 +32,13 @@ func (s *settings) apply(opts []ClientOption) {
 
 func (s *settings) validate() error {
 	var err error
-	if s.Token == nil {
+	if s.token == nil {
 		return fmt.Errorf("no credential option provided")
 	}
 
-	_, err = url.Parse(s.ApiUrl)
+	_, err = url.Parse(s.apiUrl)
 	if err != nil {
-		return fmt.Errorf("invalid url %s: %s", s.ApiUrl, err)
+		return fmt.Errorf("invalid url %s: %s", s.apiUrl, err)
 	}
 
 	return nil

--- a/scw/settings_test.go
+++ b/scw/settings_test.go
@@ -18,8 +18,8 @@ func TestSettings(t *testing.T) {
 
 	// Apply
 	var funcToApply ClientOption = func(s *settings) {
-		s.Token = auth.NewToken(testAccessKey, testSecretKey)
-		s.ApiUrl = apiUrl
+		s.token = auth.NewToken(testAccessKey, testSecretKey)
+		s.apiUrl = apiUrl
 	}
 
 	s.apply([]ClientOption{funcToApply})
@@ -35,7 +35,7 @@ func TestSettingsInvalidToken(t *testing.T) {
 
 	// Apply
 	var setURL ClientOption = func(s *settings) {
-		s.ApiUrl = apiUrl
+		s.apiUrl = apiUrl
 	}
 
 	s.apply([]ClientOption{setURL})
@@ -51,8 +51,8 @@ func TestSettingsInvalidURL(t *testing.T) {
 
 	// Apply
 	var setTokenUnsetURL ClientOption = func(s *settings) {
-		s.ApiUrl = ":test"
-		s.Token = auth.NewToken(testAccessKey, testSecretKey)
+		s.apiUrl = ":test"
+		s.token = auth.NewToken(testAccessKey, testSecretKey)
 	}
 
 	s.apply([]ClientOption{setTokenUnsetURL})

--- a/scw/settings_test.go
+++ b/scw/settings_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	URL = "https://example.com/"
+	apiUrl = "https://example.com/"
 )
 
 func TestSettings(t *testing.T) {
@@ -19,7 +19,7 @@ func TestSettings(t *testing.T) {
 	// Apply
 	var funcToApply ClientOption = func(s *settings) {
 		s.Token = auth.NewToken(testAccessKey, testSecretKey)
-		s.Url = URL
+		s.ApiUrl = apiUrl
 	}
 
 	s.apply([]ClientOption{funcToApply})
@@ -35,7 +35,7 @@ func TestSettingsInvalidToken(t *testing.T) {
 
 	// Apply
 	var setURL ClientOption = func(s *settings) {
-		s.Url = URL
+		s.ApiUrl = apiUrl
 	}
 
 	s.apply([]ClientOption{setURL})
@@ -51,7 +51,7 @@ func TestSettingsInvalidURL(t *testing.T) {
 
 	// Apply
 	var setTokenUnsetURL ClientOption = func(s *settings) {
-		s.Url = ":test"
+		s.ApiUrl = ":test"
 		s.Token = auth.NewToken(testAccessKey, testSecretKey)
 	}
 


### PR DESCRIPTION
Implemented three new `ClientOption`:

- `WithDefaultOrganizationId` client option sets the client default organization ID.  
It will be used as the default value of the organization_id field in all requests made with this client.
- `WithDefaultRegion` client option sets the client default region.  
It will be used as the default value of the region field in all requests made with this client.
- `WithDefaultZone` client option sets the client default zone.  
It will be used as the default value of the zone field in all requests made with this client.