### PR TITLE
feat: implement WithConfig client option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,13 @@ import (
 
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
-	"github.com/scaleway/scaleway-sdk-go/scwconfig"
 )
 
 func main() {
 
-	// Get Scaleway Config
-	config, err := scwconfig.Load() // Get your credentials at https://console.scaleway.com/account/credentials
-	if err != nil {
-    panic(err)
-  }
-
 	// Create a Scaleway client
 	client, err := scw.NewClient(
-		scw.WithConfig(config),
+		scw.WithAuth("ACCESS_KEY", "SECRET_KEY"), // Get your credentials at https://console.scaleway.com/account/credentials
 	)
 	if err != nil {
 		panic(err)
@@ -70,7 +63,6 @@ func main() {
 	}
 
 }
-
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -34,13 +34,20 @@ import (
 
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
+	"github.com/scaleway/scaleway-sdk-go/scwconfig"
 )
 
 func main() {
 
+	// Get Scaleway Config
+	config, err := scwconfig.Load() // Get your credentials at https://console.scaleway.com/account/credentials
+	if err != nil {
+    panic(err)
+  }
+
 	// Create a Scaleway client
 	client, err := scw.NewClient(
-		scw.WithAuth("ACCESS_KEY", "SECRET_KEY"), // Get your credentials at https://console.scaleway.com/account/credentials
+		scw.WithConfig(config),
 	)
 	if err != nil {
 		panic(err)

--- a/api/instance/v1/instance_sdk.go
+++ b/api/instance/v1/instance_sdk.go
@@ -726,7 +726,7 @@ type VolumeTemplate struct {
 // Service Api
 
 type GetServerTypesAvailabilityRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	PerPage *int32 `json:"-"`
 
@@ -768,7 +768,7 @@ func (s *Api) GetServerTypesAvailability(req *GetServerTypesAvailabilityRequest)
 }
 
 type ListServersTypesRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	PerPage *int32 `json:"-"`
 
@@ -810,7 +810,7 @@ func (s *Api) ListServersTypes(req *ListServersTypesRequest) (*ListServersTypesR
 }
 
 type ListServersRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	Organization *string `json:"-"`
 
@@ -858,7 +858,7 @@ func (s *Api) ListServers(req *ListServersRequest) (*ListServersResponse, error)
 }
 
 type CreateServerRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 	// Name: display the server name
 	Name string `json:"name,omitempty"`
 	// DynamicIpRequired: define if a dynamic IP is required for the instance
@@ -918,7 +918,7 @@ func (s *Api) CreateServer(req *CreateServerRequest) (*CreateServerResponse, err
 }
 
 type DeleteServerRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	ServerId string `json:"-"`
 }
@@ -948,7 +948,7 @@ func (s *Api) DeleteServer(req *DeleteServerRequest) error {
 }
 
 type GetServerRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	ServerId string `json:"-"`
 }
@@ -984,7 +984,7 @@ func (s *Api) GetServer(req *GetServerRequest) (*GetServerResponse, error) {
 }
 
 type SetServerRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 	// Id: display the server unique ID
 	Id string `json:"-"`
 	// Name: display the server name
@@ -1079,7 +1079,7 @@ func (s *Api) SetServer(req *SetServerRequest) (*SetServerResponse, error) {
 }
 
 type UpdateServerRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	ServerId string `json:"-"`
 
@@ -1139,7 +1139,7 @@ func (s *Api) UpdateServer(req *UpdateServerRequest) (*UpdateServerResponse, err
 }
 
 type ListServerActionsRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	ServerId string `json:"-"`
 }
@@ -1175,7 +1175,7 @@ func (s *Api) ListServerActions(req *ListServerActionsRequest) (*ListServerActio
 }
 
 type ServerActionRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	ServerId string `json:"-"`
 
@@ -1219,7 +1219,7 @@ func (s *Api) ServerAction(req *ServerActionRequest) (*ServerActionResponse, err
 }
 
 type ListServerUserDataRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	ServerId string `json:"-"`
 }
@@ -1255,7 +1255,7 @@ func (s *Api) ListServerUserData(req *ListServerUserDataRequest) (*ListServerUse
 }
 
 type DeleteServerUserDataRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	ServerId string `json:"-"`
 
@@ -1287,7 +1287,7 @@ func (s *Api) DeleteServerUserData(req *DeleteServerUserDataRequest) error {
 }
 
 type SetServerUserDataRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	ServerId string `json:"-"`
 
@@ -1327,7 +1327,7 @@ func (s *Api) SetServerUserData(req *SetServerUserDataRequest) error {
 }
 
 type GetServerUserDataRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	ServerId string `json:"-"`
 
@@ -1365,7 +1365,7 @@ func (s *Api) GetServerUserData(req *GetServerUserDataRequest) (*utils.File, err
 }
 
 type ListImagesRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	Organization *string `json:"-"`
 
@@ -1424,7 +1424,7 @@ func (s *Api) ListImages(req *ListImagesRequest) (*ListImagesResponse, error) {
 }
 
 type GetImageRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	ImageId string `json:"-"`
 }
@@ -1460,7 +1460,7 @@ func (s *Api) GetImage(req *GetImageRequest) (*GetImageResponse, error) {
 }
 
 type CreateImageRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	Name string `json:"name,omitempty"`
 
@@ -1514,7 +1514,7 @@ func (s *Api) CreateImage(req *CreateImageRequest) (*CreateImageResponse, error)
 }
 
 type SetImageRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	Id string `json:"-"`
 
@@ -1582,7 +1582,7 @@ func (s *Api) SetImage(req *SetImageRequest) (*SetImageResponse, error) {
 }
 
 type DeleteImageRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	ImageId string `json:"-"`
 }
@@ -1612,7 +1612,7 @@ func (s *Api) DeleteImage(req *DeleteImageRequest) error {
 }
 
 type ListSnapshotsRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	Organization *string `json:"-"`
 
@@ -1663,7 +1663,7 @@ func (s *Api) ListSnapshots(req *ListSnapshotsRequest) (*ListSnapshotsResponse, 
 }
 
 type CreateSnapshotRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	VolumeId string `json:"volume_id,omitempty"`
 
@@ -1711,7 +1711,7 @@ func (s *Api) CreateSnapshot(req *CreateSnapshotRequest) (*CreateSnapshotRespons
 }
 
 type GetSnapshotRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	SnapshotId string `json:"-"`
 }
@@ -1747,7 +1747,7 @@ func (s *Api) GetSnapshot(req *GetSnapshotRequest) (*GetSnapshotResponse, error)
 }
 
 type SetSnapshotRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	Id string `json:"-"`
 
@@ -1809,7 +1809,7 @@ func (s *Api) SetSnapshot(req *SetSnapshotRequest) (*SetSnapshotResponse, error)
 }
 
 type DeleteSnapshotRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	SnapshotId string `json:"-"`
 }
@@ -1839,7 +1839,7 @@ func (s *Api) DeleteSnapshot(req *DeleteSnapshotRequest) error {
 }
 
 type ListVolumesRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	Organization *string `json:"-"`
 
@@ -1890,7 +1890,7 @@ func (s *Api) ListVolumes(req *ListVolumesRequest) (*ListVolumesResponse, error)
 }
 
 type CreateVolumeRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	Name string `json:"name,omitempty"`
 
@@ -1959,7 +1959,7 @@ func (s *Api) CreateVolume(req *CreateVolumeRequest) (*CreateVolumeResponse, err
 }
 
 type GetVolumeRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	VolumeId string `json:"-"`
 }
@@ -1995,7 +1995,7 @@ func (s *Api) GetVolume(req *GetVolumeRequest) (*GetVolumeResponse, error) {
 }
 
 type SetVolumeRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 	// Id: display the volumes unique ID
 	Id string `json:"-"`
 	// Name: display the volumes names
@@ -2059,7 +2059,7 @@ func (s *Api) SetVolume(req *SetVolumeRequest) (*SetVolumeResponse, error) {
 }
 
 type DeleteVolumeRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	VolumeId string `json:"-"`
 }
@@ -2089,7 +2089,7 @@ func (s *Api) DeleteVolume(req *DeleteVolumeRequest) error {
 }
 
 type ListSecurityGroupsRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	Organization *string `json:"-"`
 
@@ -2139,7 +2139,7 @@ func (s *Api) ListSecurityGroups(req *ListSecurityGroupsRequest) (*ListSecurityG
 }
 
 type CreateSecurityGroupRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	Name string `json:"name,omitempty"`
 
@@ -2189,7 +2189,7 @@ func (s *Api) CreateSecurityGroup(req *CreateSecurityGroupRequest) (*CreateSecur
 }
 
 type GetSecurityGroupRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	SecurityGroupId string `json:"-"`
 }
@@ -2225,7 +2225,7 @@ func (s *Api) GetSecurityGroup(req *GetSecurityGroupRequest) (*GetSecurityGroupR
 }
 
 type DeleteSecurityGroupRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	SecurityGroupId string `json:"-"`
 }
@@ -2253,7 +2253,7 @@ func (s *Api) DeleteSecurityGroup(req *DeleteSecurityGroupRequest) error {
 }
 
 type SetSecurityGroupRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 	// Id: display the security groups' unique ID
 	Id string `json:"-"`
 	// Name: display the security groups name
@@ -2321,7 +2321,7 @@ func (s *Api) SetSecurityGroup(req *SetSecurityGroupRequest) (*UpdateSecurityGro
 }
 
 type ListSecurityGroupRulesRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	SecurityGroupId string `json:"-"`
 
@@ -2363,7 +2363,7 @@ func (s *Api) ListSecurityGroupRules(req *ListSecurityGroupRulesRequest) (*ListS
 }
 
 type CreateSecurityGroupRuleRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	SecurityGroupId string `json:"-"`
 
@@ -2419,7 +2419,7 @@ func (s *Api) CreateSecurityGroupRule(req *CreateSecurityGroupRuleRequest) (*Cre
 }
 
 type DeleteSecurityGroupRuleRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	SecurityGroupId string `json:"-"`
 
@@ -2451,7 +2451,7 @@ func (s *Api) DeleteSecurityGroupRule(req *DeleteSecurityGroupRuleRequest) error
 }
 
 type GetSecurityGroupRuleRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	SecurityGroupId string `json:"-"`
 
@@ -2489,7 +2489,7 @@ func (s *Api) GetSecurityGroupRule(req *GetSecurityGroupRuleRequest) (*GetSecuri
 }
 
 type ListIpsRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	Organization string `json:"-"`
 
@@ -2533,7 +2533,7 @@ func (s *Api) ListIps(req *ListIpsRequest) (*ListIpsResponse, error) {
 }
 
 type CreateIpRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	Organization string `json:"organization,omitempty"`
 
@@ -2579,7 +2579,7 @@ func (s *Api) CreateIp(req *CreateIpRequest) (*CreateIpResponse, error) {
 }
 
 type GetIpRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	IpId string `json:"-"`
 }
@@ -2615,7 +2615,7 @@ func (s *Api) GetIp(req *GetIpRequest) (*GetIpResponse, error) {
 }
 
 type SetIpRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	Id string `json:"-"`
 
@@ -2666,7 +2666,7 @@ func (s *Api) SetIp(req *SetIpRequest) (*SetIpResponse, error) {
 }
 
 type UpdateIpRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	IpId string `json:"-"`
 
@@ -2710,7 +2710,7 @@ func (s *Api) UpdateIp(req *UpdateIpRequest) (*UpdateIpResponse, error) {
 }
 
 type DeleteIpRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	IpId string `json:"-"`
 }
@@ -2740,7 +2740,7 @@ func (s *Api) DeleteIp(req *DeleteIpRequest) error {
 }
 
 type ListBootscriptsRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	Arch *string `json:"-"`
 
@@ -2786,7 +2786,7 @@ func (s *Api) ListBootscripts(req *ListBootscriptsRequest) (*ListBootscriptsResp
 }
 
 type GetBootscriptRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	BootscriptId string `json:"-"`
 }
@@ -2822,7 +2822,7 @@ func (s *Api) GetBootscript(req *GetBootscriptRequest) (*GetBootscriptResponse, 
 }
 
 type GetServiceInfoRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 }
 
 func (s *Api) GetServiceInfo(req *GetServiceInfoRequest) (*GetServiceInfoResponse, error) {
@@ -2853,7 +2853,7 @@ func (s *Api) GetServiceInfo(req *GetServiceInfoRequest) (*GetServiceInfoRespons
 }
 
 type GetDashboardRequest struct {
-	Zone scw.Zone `json:"-"`
+	Zone utils.Zone `json:"-"`
 
 	Organization *string `json:"-"`
 }

--- a/api/lb/v1/lb_sdk.go
+++ b/api/lb/v1/lb_sdk.go
@@ -502,7 +502,7 @@ type Instance struct {
 
 	IpAddress string `json:"ip_address,omitempty"`
 
-	Region scw.Region `json:"region,omitempty"`
+	Region utils.Region `json:"region,omitempty"`
 }
 
 type Ip struct {
@@ -516,7 +516,7 @@ type Ip struct {
 
 	Reverse string `json:"reverse,omitempty"`
 
-	Region scw.Region `json:"region,omitempty"`
+	Region utils.Region `json:"region,omitempty"`
 }
 
 type Lb struct {
@@ -540,7 +540,7 @@ type Lb struct {
 
 	BackendCount int32 `json:"backend_count,omitempty"`
 
-	Region scw.Region `json:"region,omitempty"`
+	Region utils.Region `json:"region,omitempty"`
 }
 
 type LbStats struct {
@@ -585,7 +585,7 @@ type ListLbsResponse struct {
 // Service Api
 
 type GetServiceInfoRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 }
 
 func (s *Api) GetServiceInfo(req *GetServiceInfoRequest) (*utils.ServiceInfo, error) {
@@ -616,7 +616,7 @@ func (s *Api) GetServiceInfo(req *GetServiceInfoRequest) (*utils.ServiceInfo, er
 }
 
 type ListLbsRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// Name: use this to search by name
 	Name *string `json:"-"`
 
@@ -670,7 +670,7 @@ func (s *Api) ListLbs(req *ListLbsRequest) (*ListLbsResponse, error) {
 }
 
 type CreateLbRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// OrganizationId: owner of resources
 	OrganizationId string `json:"organization_id,omitempty"`
 	// Name: resource names
@@ -721,7 +721,7 @@ func (s *Api) CreateLb(req *CreateLbRequest) (*Lb, error) {
 }
 
 type GetLbRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 
 	LbId string `json:"-"`
 }
@@ -754,7 +754,7 @@ func (s *Api) GetLb(req *GetLbRequest) (*Lb, error) {
 }
 
 type UpdateLbRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// LbId: load Balancer ID
 	LbId string `json:"-"`
 	// Name: resource name
@@ -799,7 +799,7 @@ func (s *Api) UpdateLb(req *UpdateLbRequest) (*Lb, error) {
 }
 
 type DeleteLbRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// LbId: load Balancer ID
 	LbId string `json:"-"`
 	// ReleaseIp: set true if you don't want to keep this IP address
@@ -832,7 +832,7 @@ func (s *Api) DeleteLb(req *DeleteLbRequest) error {
 }
 
 type ListIPsRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// Page: page number
 	Page *int32 `json:"-"`
 	// PageSize: set the maximum list size
@@ -884,7 +884,7 @@ func (s *Api) ListIPs(req *ListIPsRequest) (*ListIpsResponse, error) {
 }
 
 type GetIpRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// IpId:
 	//
 	// IP address ID
@@ -920,7 +920,7 @@ func (s *Api) GetIp(req *GetIpRequest) (*Ip, error) {
 }
 
 type ReleaseIpRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// IpId: iP address ID
 	IpId string `json:"-"`
 }
@@ -948,7 +948,7 @@ func (s *Api) ReleaseIp(req *ReleaseIpRequest) error {
 }
 
 type UpdateIpRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// IpId: iP address ID
 	IpId string `json:"-"`
 	// Reverse: reverse DNS
@@ -987,7 +987,7 @@ func (s *Api) UpdateIp(req *UpdateIpRequest) (*Ip, error) {
 }
 
 type ListBackendsRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// LbId: load Balancer ID
 	LbId string `json:"-"`
 	// Name: use this to search by name
@@ -1035,7 +1035,7 @@ func (s *Api) ListBackends(req *ListBackendsRequest) (*ListBackendsResponse, err
 }
 
 type CreateBackendRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// LbId: load Balancer ID
 	LbId string `json:"-"`
 	// Name: resource name
@@ -1140,7 +1140,7 @@ func (s *Api) CreateBackend(req *CreateBackendRequest) (*Backend, error) {
 }
 
 type GetBackendRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// BackendId: backend ID
 	BackendId string `json:"-"`
 }
@@ -1173,7 +1173,7 @@ func (s *Api) GetBackend(req *GetBackendRequest) (*Backend, error) {
 }
 
 type UpdateBackendRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// BackendId: backend ID to update
 	BackendId string `json:"-"`
 	// Name: resource name
@@ -1274,7 +1274,7 @@ func (s *Api) UpdateBackend(req *UpdateBackendRequest) (*Backend, error) {
 }
 
 type DeleteBackendRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// BackendId: iD of the backend to delete
 	BackendId string `json:"-"`
 }
@@ -1301,7 +1301,7 @@ func (s *Api) DeleteBackend(req *DeleteBackendRequest) error {
 }
 
 type AddBackendServersRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// BackendId: backend ID
 	BackendId string `json:"-"`
 	// ServerIp: set all IPs to remove of your backend
@@ -1342,7 +1342,7 @@ func (s *Api) AddBackendServers(req *AddBackendServersRequest) (*Backend, error)
 }
 
 type RemoveBackendServersRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// BackendId: backend ID
 	BackendId string `json:"-"`
 	// ServerIp: set all IPs to remove of your backend
@@ -1383,7 +1383,7 @@ func (s *Api) RemoveBackendServers(req *RemoveBackendServersRequest) (*Backend, 
 }
 
 type SetBackendServersRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// BackendId: backend ID
 	BackendId string `json:"-"`
 	// ServerIp: set all IPs to add of your backend and remove all other
@@ -1424,7 +1424,7 @@ func (s *Api) SetBackendServers(req *SetBackendServersRequest) (*Backend, error)
 }
 
 type UpdateHealthCheckRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// BackendId: backend ID
 	BackendId string `json:"-"`
 	// Port: specify the port used to health check
@@ -1543,7 +1543,7 @@ func (s *Api) UpdateHealthCheck(req *UpdateHealthCheckRequest) (*HealthCheck, er
 }
 
 type ListFrontendsRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// LbId: load Balancer ID
 	LbId string `json:"-"`
 	// Name: use this to search by name
@@ -1591,7 +1591,7 @@ func (s *Api) ListFrontends(req *ListFrontendsRequest) (*ListFrontendsResponse, 
 }
 
 type CreateFrontendRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// LbId: load Balancer ID
 	LbId string `json:"-"`
 	// Name: resource name
@@ -1670,7 +1670,7 @@ func (s *Api) CreateFrontend(req *CreateFrontendRequest) (*Frontend, error) {
 }
 
 type GetFrontendRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// FrontendId: frontend ID
 	FrontendId string `json:"-"`
 }
@@ -1703,7 +1703,7 @@ func (s *Api) GetFrontend(req *GetFrontendRequest) (*Frontend, error) {
 }
 
 type UpdateFrontendRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// FrontendId: frontend ID
 	FrontendId string `json:"-"`
 	// Name: resource name
@@ -1782,7 +1782,7 @@ func (s *Api) UpdateFrontend(req *UpdateFrontendRequest) (*Frontend, error) {
 }
 
 type DeleteFrontendRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// FrontendId: frontend ID to delete
 	FrontendId string `json:"-"`
 }
@@ -1809,7 +1809,7 @@ func (s *Api) DeleteFrontend(req *DeleteFrontendRequest) error {
 }
 
 type GetLbStatsRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// LbId: load Balancer ID
 	LbId string `json:"-"`
 }
@@ -1842,7 +1842,7 @@ func (s *Api) GetLbStats(req *GetLbStatsRequest) (*LbStats, error) {
 }
 
 type ListAclsRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// FrontendId: iD of your frontend
 	FrontendId string `json:"-"`
 	// OrderBy: you can order the response by created_at asc/desc or name asc/desc
@@ -1890,7 +1890,7 @@ func (s *Api) ListAcls(req *ListAclsRequest) (*ListAclResponse, error) {
 }
 
 type CreateAclRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// FrontendId: iD of your frontend
 	FrontendId string `json:"-"`
 	// Name: name of your ACL ressource
@@ -1937,7 +1937,7 @@ func (s *Api) CreateAcl(req *CreateAclRequest) (*Acl, error) {
 }
 
 type GetAclRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// AclId: iD of your ACL ressource
 	AclId string `json:"-"`
 }
@@ -1970,7 +1970,7 @@ func (s *Api) GetAcl(req *GetAclRequest) (*Acl, error) {
 }
 
 type UpdateAclRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// AclId: iD of your ACL ressource
 	AclId string `json:"-"`
 	// Name: name of your ACL ressource
@@ -2017,7 +2017,7 @@ func (s *Api) UpdateAcl(req *UpdateAclRequest) (*Acl, error) {
 }
 
 type DeleteAclRequest struct {
-	Region scw.Region `json:"-"`
+	Region utils.Region `json:"-"`
 	// AclId: iD of your ACL ressource
 	AclId string `json:"-"`
 }

--- a/example_test.go
+++ b/example_test.go
@@ -32,7 +32,10 @@ func Example_apiClient() {
 func Example_apiClientWithConfig() {
 
 	// Get Scaleway Config
-	config, err := scwconfig.Load() // Get your credentials at https://console.scaleway.com/account/credentials
+	config, err := scwconfig.Load()
+	if err != nil {
+		// handle error
+	}
 
 	// Create a Scaleway client
 	client, err := scw.NewClient(

--- a/example_test.go
+++ b/example_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 	"github.com/scaleway/scaleway-sdk-go/api/lb/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
+	"github.com/scaleway/scaleway-sdk-go/utils"
 )
 
 func Example_apiClient() {
@@ -42,7 +43,7 @@ func Example_listServers() {
 
 	// Call the ListServers method on the Instance SDK
 	response, err := instanceAPI.ListServers(&instance.ListServersRequest{
-		Zone: scw.ZoneFrPar1,
+		Zone: utils.ZoneFrPar1,
 	})
 	if err != nil {
 		// handle error
@@ -70,7 +71,7 @@ func Example_createLoadBalancer() {
 		Name:           "My new load balancer",
 		Description:    "This is a example of a load balancer",
 		OrganizationId: "000a115d-2852-4b0a-9ce8-47f1134ba95a",
-		Region:         scw.RegionFrPar,
+		Region:         utils.RegionFrPar,
 	})
 
 	if err != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 	"github.com/scaleway/scaleway-sdk-go/api/lb/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
+	"github.com/scaleway/scaleway-sdk-go/scwconfig"
 	"github.com/scaleway/scaleway-sdk-go/utils"
 )
 
@@ -14,6 +15,28 @@ func Example_apiClient() {
 	// Create a Scaleway client
 	client, err := scw.NewClient(
 		scw.WithAuth("ACCESS_KEY", "SECRET_KEY"), // Get your credentials at https://console.scaleway.com/account/credentials
+	)
+	if err != nil {
+		// handle error
+	}
+
+	// Create SDK objects for specific Scaleway Products
+	instance := instance.NewApi(client)
+	lb := lb.NewApi(client)
+
+	// Start using the SDKs
+	_, _ = instance, lb
+
+}
+
+func Example_apiClientWithConfig() {
+
+	// Get Scaleway Config
+	config, err := scwconfig.Load() // Get your credentials at https://console.scaleway.com/account/credentials
+
+	// Create a Scaleway client
+	client, err := scw.NewClient(
+		scw.WithConfig(config),
 	)
 	if err != nil {
 		// handle error

--- a/internal/testhelpers/test_helpers.go
+++ b/internal/testhelpers/test_helpers.go
@@ -34,12 +34,3 @@ func Equals(tb testing.TB, exp, act interface{}) {
 		tb.FailNow()
 	}
 }
-
-// NotNil check if val is not nil.
-func NotNil(tb testing.TB, val interface{}) {
-	if val == nil {
-		_, file, line, _ := runtime.Caller(1)
-		fmt.Printf("\033[31m%s:%d: expected a not nil value \033[39m\n\n", filepath.Base(file), line)
-		tb.FailNow()
-	}
-}

--- a/internal/testhelpers/test_helpers.go
+++ b/internal/testhelpers/test_helpers.go
@@ -34,3 +34,12 @@ func Equals(tb testing.TB, exp, act interface{}) {
 		tb.FailNow()
 	}
 }
+
+// NotNil check if val is not nil.
+func NotNil(tb testing.TB, val interface{}) {
+	if val == nil {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: expected a not nil value \033[39m\n\n", filepath.Base(file), line)
+		tb.FailNow()
+	}
+}

--- a/scw/client.go
+++ b/scw/client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/scaleway/scaleway-sdk-go/internal/auth"
+	"github.com/scaleway/scaleway-sdk-go/utils"
 )
 
 // Client is the Scaleway client which performs API requests.
@@ -20,8 +21,8 @@ type Client struct {
 	apiURL                string
 	userAgent             string
 	defaultOrganizationID string
-	defaultRegion         Region
-	defaultZone           Zone
+	defaultRegion         utils.Region
+	defaultZone           utils.Zone
 }
 
 // NewClient instantiates a new Client object.
@@ -78,14 +79,14 @@ func (c *Client) GetDefaultOrganizationID() string {
 // GetDefaultRegion return the default region of the client.
 // This value can be set from the client option
 // WithDefaultRegion(). Be aware this value can be empty.
-func (c *Client) GetDefaultRegion() Region {
+func (c *Client) GetDefaultRegion() utils.Region {
 	return c.defaultRegion
 }
 
 // GetDefaultZone return the default zone of the client.
 // This value can be set from the client option
 // WithDefaultZone(). Be aware this value can be empty.
-func (c *Client) GetDefaultZone() Zone {
+func (c *Client) GetDefaultZone() utils.Zone {
 	return c.defaultZone
 }
 

--- a/scw/client_option.go
+++ b/scw/client_option.go
@@ -56,6 +56,7 @@ func WithHTTPClient(httpClient *http.Client) ClientOption {
 // WithConfig client option configure a client with Scaleway configuration.
 func WithConfig(config scwconfig.Config) ClientOption {
 	return func(s *settings) {
+		// The access key is not used for API authentications.
 		accessKey, _ := config.GetAccessKey()
 		secretKey, secretKeyExist := config.GetSecretKey()
 		if secretKeyExist {

--- a/scw/client_option.go
+++ b/scw/client_option.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/scaleway/scaleway-sdk-go/internal/auth"
 	"github.com/scaleway/scaleway-sdk-go/scwconfig"
+	"github.com/scaleway/scaleway-sdk-go/utils"
 )
 
 // ClientOption is a function which applies options to a settings object.
@@ -78,12 +79,12 @@ func WithConfig(config scwconfig.Config) ClientOption {
 
 		defaultRegion, exist := config.GetDefaultRegion()
 		if exist {
-			s.defaultRegion = Region(defaultRegion)
+			s.defaultRegion = defaultRegion
 		}
 
 		defaultZone, exist := config.GetDefaultZone()
 		if exist {
-			s.defaultZone = Zone(defaultZone)
+			s.defaultZone = defaultZone
 		}
 	}
 }
@@ -100,7 +101,7 @@ func WithDefaultOrganizationID(organizationID string) ClientOption {
 // WithDefaultRegion client option sets the client default region.
 //
 // It will be used as the default value of the region field in all requests made with this client.
-func WithDefaultRegion(region Region) ClientOption {
+func WithDefaultRegion(region utils.Region) ClientOption {
 	return func(s *settings) {
 		s.defaultRegion = region
 	}
@@ -109,7 +110,7 @@ func WithDefaultRegion(region Region) ClientOption {
 // WithDefaultZone client option sets the client default zone.
 //
 // It will be used as the default value of the zone field in all requests made with this client.
-func WithDefaultZone(zone Zone) ClientOption {
+func WithDefaultZone(zone utils.Zone) ClientOption {
 	return func(s *settings) {
 		s.defaultZone = zone
 	}

--- a/scw/client_option.go
+++ b/scw/client_option.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/scaleway/scaleway-sdk-go/internal/auth"
+	"github.com/scaleway/scaleway-sdk-go/scwconfig"
 )
 
 // ClientOption is a function which applies options to a settings object.
@@ -48,6 +49,42 @@ func WithUserAgent(ua string) ClientOption {
 func WithHTTPClient(httpClient *http.Client) ClientOption {
 	return func(s *settings) {
 		s.httpClient = httpClient
+	}
+}
+
+// WithConfig client option configure a client with Scaleway configuration.
+func WithConfig(config scwconfig.Config) ClientOption {
+	return func(s *settings) {
+		accessKey, accessKeyExist := config.GetAccessKey()
+		secretKey, secretKeyExist := config.GetSecretKey()
+		if accessKeyExist && secretKeyExist {
+			s.token = auth.NewToken(accessKey, secretKey)
+		}
+
+		apiURL, exist := config.GetAPIURL()
+		if exist {
+			s.apiURL = apiURL
+		}
+
+		insecure, exist := config.GetInsecure()
+		if exist {
+			s.insecure = insecure
+		}
+
+		defaultOrganizationID, exist := config.GetDefaultOrganizationID()
+		if exist {
+			s.defaultOrganizationID = defaultOrganizationID
+		}
+
+		defaultRegion, exist := config.GetDefaultRegion()
+		if exist {
+			s.defaultRegion = Region(defaultRegion)
+		}
+
+		defaultZone, exist := config.GetDefaultZone()
+		if exist {
+			s.defaultZone = Zone(defaultZone)
+		}
 	}
 }
 

--- a/scw/client_option.go
+++ b/scw/client_option.go
@@ -55,9 +55,9 @@ func WithHTTPClient(httpClient *http.Client) ClientOption {
 // WithConfig client option configure a client with Scaleway configuration.
 func WithConfig(config scwconfig.Config) ClientOption {
 	return func(s *settings) {
-		accessKey, accessKeyExist := config.GetAccessKey()
+		accessKey, _ := config.GetAccessKey()
 		secretKey, secretKeyExist := config.GetSecretKey()
-		if accessKeyExist && secretKeyExist {
+		if secretKeyExist {
 			s.token = auth.NewToken(accessKey, secretKey)
 		}
 

--- a/scw/client_test.go
+++ b/scw/client_test.go
@@ -12,7 +12,7 @@ const (
 	testAPIURL                = "https://api.example.com/"
 	defaultAPIURL             = "https://api.scaleway.com"
 	testAccessKey             = "ACCESS_KEY"
-	testSecretKey             = "SECRET_KEY"
+	testSecretKey             = "539a6564-bf92-4dc9-a0d4-50e3ca827ecb"
 	testDefaultOrganizationID = "d45a075f-18a1-4e9f-824e-43914a3ae8bd"
 	testDefaultRegion         = RegionFrPar
 	testDefaultZone           = ZoneFrPar1
@@ -95,8 +95,8 @@ func TestNewClientWithOptions(t *testing.T) {
 		testhelpers.Equals(t, testAPIURL, client.apiURL)
 
 		clientTransport, ok := client.httpClient.Transport.(*http.Transport)
-		testhelpers.Equals(t, true, ok)
-		testhelpers.NotNil(t, clientTransport.TLSClientConfig)
+		testhelpers.Assert(t, ok, "clientTransport must be not nil")
+		testhelpers.Assert(t, clientTransport.TLSClientConfig != nil, "TLSClientConfig must be not nil")
 		testhelpers.Equals(t, testInsecure, clientTransport.TLSClientConfig.InsecureSkipVerify)
 
 		testhelpers.Equals(t, testDefaultOrganizationID, client.GetDefaultOrganizationID())

--- a/scw/client_test.go
+++ b/scw/client_test.go
@@ -13,8 +13,8 @@ const (
 	testAPIURL                = "https://api.example.com/"
 	defaultAPIURL             = "https://api.scaleway.com"
 	testAccessKey             = "ACCESS_KEY"
-	testSecretKey             = "7363616C-6577-6573-6862-6F7579616161" // | xxd -ps -r
-	testDefaultOrganizationID = "6170692E-7363-616C-6577-61792E636F6D" // | xxd -ps -r
+	testSecretKey             = "7363616c-6577-6573-6862-6f7579616161" // hint: | xxd -ps -r
+	testDefaultOrganizationID = "6170692e-7363-616c-6577-61792e636f6d" // hint: | xxd -ps -r
 	testDefaultRegion         = utils.RegionFrPar
 	testDefaultZone           = utils.ZoneFrPar1
 	testInsecure              = true

--- a/scw/client_test.go
+++ b/scw/client_test.go
@@ -13,8 +13,8 @@ const (
 	testAPIURL                = "https://api.example.com/"
 	defaultAPIURL             = "https://api.scaleway.com"
 	testAccessKey             = "ACCESS_KEY"
-	testSecretKey             = "539a6564-bf92-4dc9-a0d4-50e3ca827ecb"
-	testDefaultOrganizationID = "d45a075f-18a1-4e9f-824e-43914a3ae8bd"
+	testSecretKey             = "7363616C-6577-6573-6862-6F7579616161" // | xxd -ps -r
+	testDefaultOrganizationID = "6170692E-7363-616C-6577-61792E636F6D" // | xxd -ps -r
 	testDefaultRegion         = utils.RegionFrPar
 	testDefaultZone           = utils.ZoneFrPar1
 	testInsecure              = true

--- a/scw/client_test.go
+++ b/scw/client_test.go
@@ -11,11 +11,12 @@ import (
 const (
 	testAPIURL                = "https://api.example.com/"
 	defaultAPIURL             = "https://api.scaleway.com"
-	testAccessKey             = "some access key"
-	testSecretKey             = "some secret key"
-	testDefaultOrganizationID = "some default organization id"
+	testAccessKey             = "ACCESS_KEY"
+	testSecretKey             = "SECRET_KEY"
+	testDefaultOrganizationID = "d45a075f-18a1-4e9f-824e-43914a3ae8bd"
 	testDefaultRegion         = RegionFrPar
 	testDefaultZone           = ZoneFrPar1
+	testInsecure              = true
 )
 
 func TestNewClientWithDefaults(t *testing.T) {
@@ -33,29 +34,74 @@ func TestNewClientWithDefaults(t *testing.T) {
 
 }
 
+type TestConfig struct{}
+
+func (c *TestConfig) GetAccessKey() (string, bool) {
+	return testAccessKey, true
+}
+func (c *TestConfig) GetSecretKey() (secretKey string, exist bool) {
+	return testSecretKey, true
+}
+func (c *TestConfig) GetAPIURL() (apiURL string, exist bool) {
+	return testAPIURL, true
+}
+func (c *TestConfig) GetInsecure() (insecure bool, exist bool) {
+	return testInsecure, true
+}
+func (c *TestConfig) GetDefaultOrganizationID() (defaultOrganizationID string, exist bool) {
+	return testDefaultOrganizationID, true
+}
+func (c *TestConfig) GetDefaultRegion() (defaultRegion string, exist bool) {
+	return string(testDefaultRegion), true
+}
+func (c *TestConfig) GetDefaultZone() (defaultZone string, exist bool) {
+	return string(testDefaultZone), true
+}
+
 func TestNewClientWithOptions(t *testing.T) {
 
-	someHTTPClient := &http.Client{}
+	t.Run("Basic", func(t *testing.T) {
+		someHTTPClient := &http.Client{}
 
-	options := []ClientOption{
-		WithAPIURL(testAPIURL),
-		WithAuth(testAccessKey, testSecretKey),
-		WithHTTPClient(someHTTPClient),
-		WithDefaultOrganizationID(testDefaultOrganizationID),
-		WithDefaultRegion(testDefaultRegion),
-		WithDefaultZone(testDefaultZone),
-	}
+		options := []ClientOption{
+			WithAPIURL(testAPIURL),
+			WithAuth(testAccessKey, testSecretKey),
+			WithHTTPClient(someHTTPClient),
+			WithDefaultOrganizationID(testDefaultOrganizationID),
+			WithDefaultRegion(testDefaultRegion),
+			WithDefaultZone(testDefaultZone),
+		}
 
-	client, err := NewClient(options...)
-	testhelpers.Ok(t, err)
+		client, err := NewClient(options...)
+		testhelpers.Ok(t, err)
 
-	testhelpers.Equals(t, testAPIURL, client.apiURL)
-	testhelpers.Equals(t, auth.NewToken(testAccessKey, testSecretKey), client.auth)
+		testhelpers.Equals(t, testAPIURL, client.apiURL)
+		testhelpers.Equals(t, auth.NewToken(testAccessKey, testSecretKey), client.auth)
 
-	testhelpers.Equals(t, someHTTPClient, client.httpClient)
+		testhelpers.Equals(t, someHTTPClient, client.httpClient)
 
-	testhelpers.Equals(t, testDefaultOrganizationID, client.GetDefaultOrganizationID())
-	testhelpers.Equals(t, testDefaultRegion, client.GetDefaultRegion())
-	testhelpers.Equals(t, testDefaultZone, client.GetDefaultZone())
+		testhelpers.Equals(t, testDefaultOrganizationID, client.GetDefaultOrganizationID())
+		testhelpers.Equals(t, testDefaultRegion, client.GetDefaultRegion())
+		testhelpers.Equals(t, testDefaultZone, client.GetDefaultZone())
+	})
+
+	t.Run("With scwconfig", func(t *testing.T) {
+		config := &TestConfig{}
+
+		client, err := NewClient(WithConfig(config))
+		testhelpers.Ok(t, err)
+
+		testhelpers.Equals(t, auth.NewToken(testAccessKey, testSecretKey), client.auth)
+		testhelpers.Equals(t, testAPIURL, client.apiURL)
+
+		clientTransport, ok := client.httpClient.Transport.(*http.Transport)
+		testhelpers.Equals(t, true, ok)
+		testhelpers.NotNil(t, clientTransport.TLSClientConfig)
+		testhelpers.Equals(t, testInsecure, clientTransport.TLSClientConfig.InsecureSkipVerify)
+
+		testhelpers.Equals(t, testDefaultOrganizationID, client.GetDefaultOrganizationID())
+		testhelpers.Equals(t, testDefaultRegion, client.GetDefaultRegion())
+		testhelpers.Equals(t, testDefaultZone, client.GetDefaultZone())
+	})
 
 }

--- a/scw/client_test.go
+++ b/scw/client_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/scaleway/scaleway-sdk-go/internal/auth"
 	"github.com/scaleway/scaleway-sdk-go/internal/testhelpers"
+	"github.com/scaleway/scaleway-sdk-go/utils"
 )
 
 const (
@@ -14,8 +15,8 @@ const (
 	testAccessKey             = "ACCESS_KEY"
 	testSecretKey             = "539a6564-bf92-4dc9-a0d4-50e3ca827ecb"
 	testDefaultOrganizationID = "d45a075f-18a1-4e9f-824e-43914a3ae8bd"
-	testDefaultRegion         = RegionFrPar
-	testDefaultZone           = ZoneFrPar1
+	testDefaultRegion         = utils.RegionFrPar
+	testDefaultZone           = utils.ZoneFrPar1
 	testInsecure              = true
 )
 
@@ -39,23 +40,23 @@ type TestConfig struct{}
 func (c *TestConfig) GetAccessKey() (string, bool) {
 	return testAccessKey, true
 }
-func (c *TestConfig) GetSecretKey() (secretKey string, exist bool) {
+func (c *TestConfig) GetSecretKey() (string, bool) {
 	return testSecretKey, true
 }
-func (c *TestConfig) GetAPIURL() (apiURL string, exist bool) {
+func (c *TestConfig) GetAPIURL() (string, bool) {
 	return testAPIURL, true
 }
-func (c *TestConfig) GetInsecure() (insecure bool, exist bool) {
+func (c *TestConfig) GetInsecure() (bool, bool) {
 	return testInsecure, true
 }
-func (c *TestConfig) GetDefaultOrganizationID() (defaultOrganizationID string, exist bool) {
+func (c *TestConfig) GetDefaultOrganizationID() (string, bool) {
 	return testDefaultOrganizationID, true
 }
-func (c *TestConfig) GetDefaultRegion() (defaultRegion string, exist bool) {
-	return string(testDefaultRegion), true
+func (c *TestConfig) GetDefaultRegion() (utils.Region, bool) {
+	return testDefaultRegion, true
 }
-func (c *TestConfig) GetDefaultZone() (defaultZone string, exist bool) {
-	return string(testDefaultZone), true
+func (c *TestConfig) GetDefaultZone() (utils.Zone, bool) {
+	return testDefaultZone, true
 }
 
 func TestNewClientWithOptions(t *testing.T) {

--- a/scw/request_test.go
+++ b/scw/request_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/scaleway/scaleway-sdk-go/internal/auth"
-
 	"github.com/scaleway/scaleway-sdk-go/internal/testhelpers"
 )
 

--- a/scw/settings.go
+++ b/scw/settings.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	"github.com/scaleway/scaleway-sdk-go/internal/auth"
+	"github.com/scaleway/scaleway-sdk-go/utils"
 )
 
 type settings struct {
@@ -15,8 +16,8 @@ type settings struct {
 	httpClient            *http.Client
 	insecure              bool
 	defaultOrganizationID string
-	defaultRegion         Region
-	defaultZone           Zone
+	defaultRegion         utils.Region
+	defaultZone           utils.Zone
 }
 
 func newSettings() *settings {

--- a/scwconfig/config.go
+++ b/scwconfig/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/scaleway/scaleway-sdk-go/utils"
 	"gopkg.in/yaml.v2"
 )
 
@@ -57,8 +58,8 @@ type Config interface {
 	GetAPIURL() (apiURL string, exist bool)
 	GetInsecure() (insecure bool, exist bool)
 	GetDefaultOrganizationID() (defaultOrganizationID string, exist bool)
-	GetDefaultRegion() (defaultRegion string, exist bool)
-	GetDefaultZone() (defaultZone string, exist bool)
+	GetDefaultRegion() (defaultRegion utils.Region, exist bool)
+	GetDefaultZone() (defaultZone utils.Zone, exist bool)
 }
 
 type configV2 struct {
@@ -289,7 +290,7 @@ func (c *configV2) GetDefaultOrganizationID() (string, bool) {
 // value (which may be empty) is returned and the boolean is true.
 // Otherwise the returned value will be empty and the boolean will
 // be false.
-func (c *configV2) GetDefaultRegion() (string, bool) {
+func (c *configV2) GetDefaultRegion() (utils.Region, bool) {
 	envValue, envExist := getenv(scwDefaultRegionEnv, cliRegionEnv, terraformRegionEnv)
 	activeProfile, _ := c.getActiveProfile()
 
@@ -310,7 +311,7 @@ func (c *configV2) GetDefaultRegion() (string, bool) {
 		// todo: warning
 	}
 
-	return defaultRegion, true
+	return utils.Region(defaultRegion), true
 }
 
 // GetDefaultZone retrieve the default zone
@@ -321,7 +322,7 @@ func (c *configV2) GetDefaultRegion() (string, bool) {
 // value (which may be empty) is returned and the boolean is true.
 // Otherwise the returned value will be empty and the boolean will
 // be false.
-func (c *configV2) GetDefaultZone() (string, bool) {
+func (c *configV2) GetDefaultZone() (utils.Zone, bool) {
 	envValue, envExist := getenv(scwDefaultZoneEnv)
 	activeProfile, _ := c.getActiveProfile()
 
@@ -342,7 +343,7 @@ func (c *configV2) GetDefaultZone() (string, bool) {
 		// todo: warning
 	}
 
-	return defaultZone, true
+	return utils.Zone(defaultZone), true
 }
 
 func getenv(upToDateKey string, deprecatedKeys ...string) (string, bool) {

--- a/scwconfig/config_test.go
+++ b/scwconfig/config_test.go
@@ -338,18 +338,18 @@ const emptyFile = ""
 // v2 config
 var (
 	v2ValidAccessKey2             = "ACCESS_KEY2"
-	v2ValidSecretKey2             = "23cd9bbf-519f-4fc8-912e-83bbd18e4247"
+	v2ValidSecretKey2             = "6F6E6574-6F72-756C-6C74-68656D616C6C" // | xxd -ps -r
 	v2ValidAPIURL2                = "api-fr-par.scaleway.com"
 	v2ValidInsecure2              = "true"
-	v2ValidDefaultOrganizationID2 = "76ca3ea8-0a29-4e39-b4ae-f7a770868072"
+	v2ValidDefaultOrganizationID2 = "6D6F7264-6F72-6772-6561-74616761696E" // | xxd -ps -r
 	v2ValidDefaultRegion2         = string(utils.RegionFrPar)
 	v2ValidDefaultZone2           = string(utils.ZoneFrPar2)
 
 	v2ValidAccessKey             = "ACCESS_KEY"
-	v2ValidSecretKey             = "539a6564-bf92-4dc9-a0d4-50e3ca827ecb"
+	v2ValidSecretKey             = "7363616C-6577-6573-6862-6F7579616161" // | xxd -ps -r
 	v2ValidAPIURL                = "api.scaleway.com"
 	v2ValidInsecure              = "false"
-	v2ValidDefaultOrganizationID = "d45a075f-18a1-4e9f-824e-43914a3ae8bd"
+	v2ValidDefaultOrganizationID = "6170692E-7363-616C-6577-61792E636F6D" // | xxd -ps -r
 	v2ValidDefaultRegion         = string(utils.RegionNlAms)
 	v2ValidDefaultZone           = string(utils.ZoneNlAms1)
 	v2ValidProfile               = "flantier"

--- a/scwconfig/config_test.go
+++ b/scwconfig/config_test.go
@@ -338,18 +338,18 @@ const emptyFile = ""
 // v2 config
 var (
 	v2ValidAccessKey2             = "ACCESS_KEY2"
-	v2ValidSecretKey2             = "6F6E6574-6F72-756C-6C74-68656D616C6C" // | xxd -ps -r
+	v2ValidSecretKey2             = "6f6e6574-6f72-756c-6c74-68656d616c6c" // hint: | xxd -ps -r
 	v2ValidAPIURL2                = "api-fr-par.scaleway.com"
 	v2ValidInsecure2              = "true"
-	v2ValidDefaultOrganizationID2 = "6D6F7264-6F72-6772-6561-74616761696E" // | xxd -ps -r
+	v2ValidDefaultOrganizationID2 = "6d6f7264-6f72-6772-6561-74616761696e" // hint: | xxd -ps -r
 	v2ValidDefaultRegion2         = string(utils.RegionFrPar)
 	v2ValidDefaultZone2           = string(utils.ZoneFrPar2)
 
 	v2ValidAccessKey             = "ACCESS_KEY"
-	v2ValidSecretKey             = "7363616C-6577-6573-6862-6F7579616161" // | xxd -ps -r
+	v2ValidSecretKey             = "7363616c-6577-6573-6862-6f7579616161" // hint: | xxd -ps -r
 	v2ValidAPIURL                = "api.scaleway.com"
 	v2ValidInsecure              = "false"
-	v2ValidDefaultOrganizationID = "6170692E-7363-616C-6577-61792E636F6D" // | xxd -ps -r
+	v2ValidDefaultOrganizationID = "6170692e-7363-616c-6577-61792e636f6d" // hint: | xxd -ps -r
 	v2ValidDefaultRegion         = string(utils.RegionNlAms)
 	v2ValidDefaultZone           = string(utils.ZoneNlAms1)
 	v2ValidProfile               = "flantier"

--- a/scwconfig/config_test.go
+++ b/scwconfig/config_test.go
@@ -5,9 +5,18 @@ import (
 	"testing"
 
 	"github.com/scaleway/scaleway-sdk-go/internal/testhelpers"
+	"github.com/scaleway/scaleway-sdk-go/utils"
 )
 
 func s(value string) *string {
+	return &value
+}
+
+func r(value utils.Region) *utils.Region {
+	return &value
+}
+
+func z(value utils.Zone) *utils.Zone {
 	return &value
 }
 
@@ -28,8 +37,8 @@ func TestConfig(t *testing.T) {
 		expectedAPIURL                *string
 		expectedInsecure              *bool
 		expectedDefaultOrganizationID *string
-		expectedDefaultRegion         *string
-		expectedDefaultZone           *string
+		expectedDefaultRegion         *utils.Region
+		expectedDefaultZone           *utils.Zone
 	}{
 		// no env variables
 		{
@@ -72,7 +81,7 @@ func TestConfig(t *testing.T) {
 			expectedAccessKey:             s(v2ValidAccessKey),
 			expectedSecretKey:             s(v2ValidSecretKey),
 			expectedDefaultOrganizationID: s(v2ValidDefaultOrganizationID),
-			expectedDefaultRegion:         s(v2ValidDefaultRegion),
+			expectedDefaultRegion:         r(utils.Region(v2ValidDefaultRegion)),
 		},
 		{
 			name: "Simple config with valid V2", // default config path
@@ -85,7 +94,7 @@ func TestConfig(t *testing.T) {
 			expectedAccessKey:             s(v2ValidAccessKey),
 			expectedSecretKey:             s(v2ValidSecretKey),
 			expectedDefaultOrganizationID: s(v2ValidDefaultOrganizationID),
-			expectedDefaultRegion:         s(v2ValidDefaultRegion),
+			expectedDefaultRegion:         r(utils.Region(v2ValidDefaultRegion)),
 		},
 		{
 			name: "Simple config with valid V1",
@@ -110,7 +119,7 @@ func TestConfig(t *testing.T) {
 			expectedAccessKey:             s(v2ValidAccessKey),
 			expectedSecretKey:             s(v2ValidSecretKey),
 			expectedDefaultOrganizationID: s(v2ValidDefaultOrganizationID),
-			expectedDefaultRegion:         s(v2ValidDefaultRegion),
+			expectedDefaultRegion:         r(utils.Region(v2ValidDefaultRegion)),
 		},
 		{
 			name: "Complete config",
@@ -125,8 +134,8 @@ func TestConfig(t *testing.T) {
 			expectedAPIURL:                s(v2ValidAPIURL),
 			expectedInsecure:              b(false),
 			expectedDefaultOrganizationID: s(v2ValidDefaultOrganizationID),
-			expectedDefaultRegion:         s(v2ValidDefaultRegion),
-			expectedDefaultZone:           s(v2ValidDefaultZone),
+			expectedDefaultRegion:         r(utils.Region(v2ValidDefaultRegion)),
+			expectedDefaultZone:           z(utils.Zone(v2ValidDefaultZone)),
 		},
 		{
 			name: "Complete config with active profile",
@@ -141,8 +150,8 @@ func TestConfig(t *testing.T) {
 			expectedAPIURL:                s(v2ValidAPIURL2),
 			expectedInsecure:              b(true),
 			expectedDefaultOrganizationID: s(v2ValidDefaultOrganizationID2),
-			expectedDefaultRegion:         s(v2ValidDefaultRegion2),
-			expectedDefaultZone:           s(v2ValidDefaultZone2),
+			expectedDefaultRegion:         r(utils.Region(v2ValidDefaultRegion2)),
+			expectedDefaultZone:           z(utils.Zone(v2ValidDefaultZone2)),
 		},
 
 		// up-to-date env variables
@@ -162,8 +171,8 @@ func TestConfig(t *testing.T) {
 			expectedAPIURL:                s(v2ValidAPIURL),
 			expectedInsecure:              b(false),
 			expectedDefaultOrganizationID: s(v2ValidDefaultOrganizationID),
-			expectedDefaultRegion:         s(v2ValidDefaultRegion),
-			expectedDefaultZone:           s(v2ValidDefaultZone),
+			expectedDefaultRegion:         r(utils.Region(v2ValidDefaultRegion)),
+			expectedDefaultZone:           z(utils.Zone(v2ValidDefaultZone)),
 		},
 		{
 			name: "Complete config file with env variables",
@@ -185,8 +194,8 @@ func TestConfig(t *testing.T) {
 			expectedAPIURL:                s(v2ValidAPIURL2),
 			expectedInsecure:              b(true),
 			expectedDefaultOrganizationID: s(v2ValidDefaultOrganizationID2),
-			expectedDefaultRegion:         s(v2ValidDefaultRegion2),
-			expectedDefaultZone:           s(v2ValidDefaultZone2),
+			expectedDefaultRegion:         r(utils.Region(v2ValidDefaultRegion2)),
+			expectedDefaultZone:           z(utils.Zone(v2ValidDefaultZone2)),
 		},
 		{
 			name: "Complete config with active profile env variable",
@@ -202,8 +211,8 @@ func TestConfig(t *testing.T) {
 			expectedAPIURL:                s(v2ValidAPIURL2),
 			expectedInsecure:              b(true),
 			expectedDefaultOrganizationID: s(v2ValidDefaultOrganizationID2),
-			expectedDefaultRegion:         s(v2ValidDefaultRegion2),
-			expectedDefaultZone:           s(v2ValidDefaultZone2),
+			expectedDefaultRegion:         r(utils.Region(v2ValidDefaultRegion2)),
+			expectedDefaultZone:           z(utils.Zone(v2ValidDefaultZone2)),
 		},
 		{
 			name: "Complete config with active profile env variable and all env variables",
@@ -226,8 +235,8 @@ func TestConfig(t *testing.T) {
 			expectedAPIURL:                s(v2ValidAPIURL),
 			expectedInsecure:              b(false),
 			expectedDefaultOrganizationID: s(v2ValidDefaultOrganizationID),
-			expectedDefaultRegion:         s(v2ValidDefaultRegion),
-			expectedDefaultZone:           s(v2ValidDefaultZone),
+			expectedDefaultRegion:         r(utils.Region(v2ValidDefaultRegion)),
+			expectedDefaultZone:           z(utils.Zone(v2ValidDefaultZone)),
 		},
 
 		// legacy env variables
@@ -242,7 +251,7 @@ func TestConfig(t *testing.T) {
 			expectedAccessKey:             s(v2ValidAccessKey),
 			expectedSecretKey:             s(v2ValidSecretKey),
 			expectedDefaultOrganizationID: s(v2ValidDefaultOrganizationID),
-			expectedDefaultRegion:         s(v2ValidDefaultRegion),
+			expectedDefaultRegion:         r(utils.Region(v2ValidDefaultRegion)),
 		},
 		{
 			name: "No config with CLI legacy env variables",
@@ -255,7 +264,7 @@ func TestConfig(t *testing.T) {
 			expectedSecretKey:             s(v2ValidSecretKey2),
 			expectedInsecure:              b(true),
 			expectedDefaultOrganizationID: s(v2ValidDefaultOrganizationID2),
-			expectedDefaultRegion:         s(v2ValidDefaultRegion2),
+			expectedDefaultRegion:         r(utils.Region(v2ValidDefaultRegion2)),
 		},
 	}
 
@@ -333,16 +342,16 @@ var (
 	v2ValidAPIURL2                = "api-fr-par.scaleway.com"
 	v2ValidInsecure2              = "true"
 	v2ValidDefaultOrganizationID2 = "76ca3ea8-0a29-4e39-b4ae-f7a770868072"
-	v2ValidDefaultRegion2         = "fr-par"
-	v2ValidDefaultZone2           = "fr-par-2"
+	v2ValidDefaultRegion2         = string(utils.RegionFrPar)
+	v2ValidDefaultZone2           = string(utils.ZoneFrPar2)
 
 	v2ValidAccessKey             = "ACCESS_KEY"
 	v2ValidSecretKey             = "539a6564-bf92-4dc9-a0d4-50e3ca827ecb"
 	v2ValidAPIURL                = "api.scaleway.com"
 	v2ValidInsecure              = "false"
 	v2ValidDefaultOrganizationID = "d45a075f-18a1-4e9f-824e-43914a3ae8bd"
-	v2ValidDefaultRegion         = "nl-ams"
-	v2ValidDefaultZone           = "nl-ams-1"
+	v2ValidDefaultRegion         = string(utils.RegionNlAms)
+	v2ValidDefaultZone           = string(utils.ZoneNlAms1)
 	v2ValidProfile               = "flantier"
 
 	v2SimpleValidConfig = &configV2{

--- a/utils/locality.go
+++ b/utils/locality.go
@@ -1,4 +1,4 @@
-package scw
+package utils
 
 // Region is a geographical location
 type Region string
@@ -13,5 +13,6 @@ type Zone string
 
 const (
 	ZoneFrPar1 = Zone("fr-par-1")
+	ZoneFrPar2 = Zone("fr-par-2")
 	ZoneNlAms1 = Zone("nl-ams-1")
 )


### PR DESCRIPTION
- Implement a `func WithConfig(config scwconfig.Config) ClientOption` to configure a client with Scaleway configuration.
- Move `scw.{Region|Zone}` to `utils` package.