### PR TITLE
Fix: content length

### DIFF
--- a/api/instance/v1/instance_sdk.go
+++ b/api/instance/v1/instance_sdk.go
@@ -901,7 +901,7 @@ func (s *Api) CreateServer(req *CreateServerRequest) (*CreateServerResponse, err
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -1062,7 +1062,7 @@ func (s *Api) SetServer(req *SetServerRequest) (*SetServerResponse, error) {
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -1122,7 +1122,7 @@ func (s *Api) UpdateServer(req *UpdateServerRequest) (*UpdateServerResponse, err
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -1202,7 +1202,7 @@ func (s *Api) ServerAction(req *ServerActionRequest) (*ServerActionResponse, err
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -1316,7 +1316,7 @@ func (s *Api) SetServerUserData(req *SetServerUserDataRequest) error {
 		return err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	_, err = s.client.Do(scwReq)
 
@@ -1497,7 +1497,7 @@ func (s *Api) CreateImage(req *CreateImageRequest) (*CreateImageResponse, error)
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -1565,7 +1565,7 @@ func (s *Api) SetImage(req *SetImageRequest) (*SetImageResponse, error) {
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -1694,7 +1694,7 @@ func (s *Api) CreateSnapshot(req *CreateSnapshotRequest) (*CreateSnapshotRespons
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -1792,7 +1792,7 @@ func (s *Api) SetSnapshot(req *SetSnapshotRequest) (*SetSnapshotResponse, error)
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -1942,7 +1942,7 @@ func (s *Api) CreateVolume(req *CreateVolumeRequest) (*CreateVolumeResponse, err
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -2042,7 +2042,7 @@ func (s *Api) SetVolume(req *SetVolumeRequest) (*SetVolumeResponse, error) {
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -2172,7 +2172,7 @@ func (s *Api) CreateSecurityGroup(req *CreateSecurityGroupRequest) (*CreateSecur
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -2304,7 +2304,7 @@ func (s *Api) SetSecurityGroup(req *SetSecurityGroupRequest) (*UpdateSecurityGro
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -2402,7 +2402,7 @@ func (s *Api) CreateSecurityGroupRule(req *CreateSecurityGroupRuleRequest) (*Cre
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -2562,7 +2562,7 @@ func (s *Api) CreateIp(req *CreateIpRequest) (*CreateIpResponse, error) {
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -2649,7 +2649,7 @@ func (s *Api) SetIp(req *SetIpRequest) (*SetIpResponse, error) {
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -2693,7 +2693,7 @@ func (s *Api) UpdateIp(req *UpdateIpRequest) (*UpdateIpResponse, error) {
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 

--- a/api/lb/v1/lb_sdk.go
+++ b/api/lb/v1/lb_sdk.go
@@ -704,7 +704,7 @@ func (s *Api) CreateLb(req *CreateLbRequest) (*Lb, error) {
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -782,7 +782,7 @@ func (s *Api) UpdateLb(req *UpdateLbRequest) (*Lb, error) {
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -1123,7 +1123,7 @@ func (s *Api) CreateBackend(req *CreateBackendRequest) (*Backend, error) {
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -1257,7 +1257,7 @@ func (s *Api) UpdateBackend(req *UpdateBackendRequest) (*Backend, error) {
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -1325,7 +1325,7 @@ func (s *Api) AddBackendServers(req *AddBackendServersRequest) (*Backend, error)
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -1366,7 +1366,7 @@ func (s *Api) RemoveBackendServers(req *RemoveBackendServersRequest) (*Backend, 
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -1407,7 +1407,7 @@ func (s *Api) SetBackendServers(req *SetBackendServersRequest) (*Backend, error)
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -1526,7 +1526,7 @@ func (s *Api) UpdateHealthCheck(req *UpdateHealthCheckRequest) (*HealthCheck, er
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -1653,7 +1653,7 @@ func (s *Api) CreateFrontend(req *CreateFrontendRequest) (*Frontend, error) {
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -1765,7 +1765,7 @@ func (s *Api) UpdateFrontend(req *UpdateFrontendRequest) (*Frontend, error) {
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -1920,7 +1920,7 @@ func (s *Api) CreateAcl(req *CreateAclRequest) (*Acl, error) {
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 
@@ -2000,7 +2000,7 @@ func (s *Api) UpdateAcl(req *UpdateAclRequest) (*Acl, error) {
 		return nil, err
 	}
 	scwReq.Headers.Add("Content-Type", body.ContentType())
-	scwReq.Body = body
+	scwReq.Body = body.Reader
 
 	scwResp, err := s.client.Do(scwReq)
 

--- a/internal/marshaler/body_marshaler.go
+++ b/internal/marshaler/body_marshaler.go
@@ -4,14 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 
 	"github.com/scaleway/scaleway-sdk-go/utils"
 )
 
 // Body is an HTTP Body with a content-type
 type Body struct {
-	io.ReadCloser
+	io.Reader
 	contentType string
 }
 
@@ -27,14 +26,14 @@ func MarshalBody(body interface{}) (*Body, error) {
 	switch b := body.(type) {
 	case *utils.File:
 		res.contentType = b.ContentType
-		res.ReadCloser = ioutil.NopCloser(b.Content)
+		res.Reader = b.Content
 	default:
 		buf, err := json.Marshal(body)
 		if err != nil {
 			return nil, err
 		}
 		res.contentType = "application/json"
-		res.ReadCloser = ioutil.NopCloser(bytes.NewBuffer(buf))
+		res.Reader = bytes.NewReader(buf)
 	}
 
 	return res, nil


### PR DESCRIPTION
Fix #24 

Content length was not set in default request. It was using a custom Reader (internal/marshaler.Body) which is not known by [http.NewRequest](https://golang.org/src/net/http/request.go?s=26724:26793#L834), causing the request to have no ContentLength.