### PR TITLE
style: better http error message

### DIFF
--- a/scw/errors.go
+++ b/scw/errors.go
@@ -19,6 +19,9 @@ type ResponseError struct {
 
 	// StatusCode is the HTTP status code received
 	StatusCode int `json:"-"`
+
+	// Status is the HTTP status received
+	Status string `json:"-"`
 }
 
 func hasResponseError(res *http.Response) error {
@@ -27,6 +30,7 @@ func hasResponseError(res *http.Response) error {
 	}
 	newErr := &ResponseError{
 		StatusCode: res.StatusCode,
+		Status:     res.Status,
 	}
 
 	if res.Body == nil {
@@ -44,18 +48,15 @@ func hasResponseError(res *http.Response) error {
 }
 
 func (e *ResponseError) Error() string {
-	s := fmt.Sprintf("received status code %d", e.StatusCode)
-
-	if e.Type != "" {
-		s = fmt.Sprintf("%s: error type is %s", s, e.Type)
-	}
+	s := fmt.Sprintf("scaleway-sdk-go: http error %s", e.Status)
 
 	if e.Message != "" {
 		s = fmt.Sprintf("%s: %s", s, e.Message)
 	}
 
 	if len(e.Fields) > 0 {
-		s = fmt.Sprintf("%s: details: %v", s, e.Fields)
+		s = fmt.Sprintf("%s: %v", s, e.Fields)
 	}
+
 	return s
 }

--- a/scw/errors_test.go
+++ b/scw/errors_test.go
@@ -35,6 +35,7 @@ func TestHasResponseErrorWithValidError(t *testing.T) {
 		errorType       = "some type"
 		errorFields     = map[string][]string{"some_field": {"some_value"}}
 		errorStatusCode = 400
+		errorStatus     = "400 Bad Request"
 	)
 
 	// Create expected error response
@@ -43,12 +44,13 @@ func TestHasResponseErrorWithValidError(t *testing.T) {
 		Type:       errorType,
 		Fields:     errorFields,
 		StatusCode: errorStatusCode,
+		Status:     errorStatus,
 	}
 
 	// Create response body with marshalled error response
 	bodyBytes, err := json.Marshal(testErrorReponse)
 	testhelpers.Ok(t, err)
-	res := &http.Response{StatusCode: errorStatusCode, Body: ioutil.NopCloser(bytes.NewReader(bodyBytes))}
+	res := &http.Response{Status: errorStatus, StatusCode: errorStatusCode, Body: ioutil.NopCloser(bytes.NewReader(bodyBytes))}
 
 	// Test hasResponseError()
 	newErr := hasResponseError(res)


### PR DESCRIPTION
Improve Http error string message:
```
panic: http request [GET https://api.scaleway.com/instance/v1/zones/fr-par-1/servers?organization=] return [400 Bad Request]
{
  "message": "Validation Error",
  "type": "invalid_request_error",
  "fields": {
    "organization": [
      " is not a valid UUID."
    ]
  }
}
```