### PR TITLE
refactor: client getters

### DIFF
--- a/api/instance/v1/instance_sdk.go
+++ b/api/instance/v1/instance_sdk.go
@@ -852,8 +852,10 @@ func (s *API) GetServerTypesAvailability(req *GetServerTypesAvailabilityRequest,
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
+
 	query := url.Values{}
 	parameter.AddToQuery(query, "per_page", req.PerPage)
 	parameter.AddToQuery(query, "page", req.Page)
@@ -889,8 +891,10 @@ func (s *API) ListServersTypes(req *ListServersTypesRequest, opts ...scw.Request
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
+
 	query := url.Values{}
 	parameter.AddToQuery(query, "per_page", req.PerPage)
 	parameter.AddToQuery(query, "page", req.Page)
@@ -925,14 +929,16 @@ type ListServersRequest struct {
 func (s *API) ListServers(req *ListServersRequest, opts ...scw.RequestOption) (*ListServersResponse, error) {
 	var err error
 
-	val := s.client.GetDefaultOrganizationID()
-	if (req.Organization == nil || *req.Organization == "") && string(val) != "" {
-		req.Organization = &val
+	defaultOrganization, exist := s.client.GetDefaultOrganizationID()
+	if (req.Organization == nil || *req.Organization == "") && exist {
+		req.Organization = &defaultOrganization
 	}
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
+
 	query := url.Values{}
 	parameter.AddToQuery(query, "organization", req.Organization)
 	parameter.AddToQuery(query, "per_page", req.PerPage)
@@ -983,11 +989,13 @@ func (s *API) CreateServer(req *CreateServerRequest, opts ...scw.RequestOption) 
 	var err error
 
 	if req.Organization == "" {
-		req.Organization = s.client.GetDefaultOrganizationID()
+		defaultOrganization, _ := s.client.GetDefaultOrganizationID()
+		req.Organization = defaultOrganization
 	}
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -995,6 +1003,7 @@ func (s *API) CreateServer(req *CreateServerRequest, opts ...scw.RequestOption) 
 		Path:    "/instance/v1/zones/" + fmt.Sprint(req.Zone) + "/servers",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -1022,7 +1031,8 @@ func (s *API) DeleteServer(req *DeleteServerRequest, opts ...scw.RequestOption) 
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1051,7 +1061,8 @@ func (s *API) GetServer(req *GetServerRequest, opts ...scw.RequestOption) (*GetS
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1131,11 +1142,13 @@ func (s *API) SetServer(req *SetServerRequest, opts ...scw.RequestOption) (*SetS
 	var err error
 
 	if req.Organization == "" {
-		req.Organization = s.client.GetDefaultOrganizationID()
+		defaultOrganization, _ := s.client.GetDefaultOrganizationID()
+		req.Organization = defaultOrganization
 	}
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1143,6 +1156,7 @@ func (s *API) SetServer(req *SetServerRequest, opts ...scw.RequestOption) (*SetS
 		Path:    "/instance/v1/zones/" + fmt.Sprint(req.Zone) + "/servers/" + fmt.Sprint(req.ID) + "",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -1188,7 +1202,8 @@ func (s *API) UpdateServer(req *UpdateServerRequest, opts ...scw.RequestOption) 
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1196,6 +1211,7 @@ func (s *API) UpdateServer(req *UpdateServerRequest, opts ...scw.RequestOption) 
 		Path:    "/instance/v1/zones/" + fmt.Sprint(req.Zone) + "/servers/" + fmt.Sprint(req.ServerID) + "",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -1223,7 +1239,8 @@ func (s *API) ListServerActions(req *ListServerActionsRequest, opts ...scw.Reque
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1256,7 +1273,8 @@ func (s *API) ServerAction(req *ServerActionRequest, opts ...scw.RequestOption) 
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1264,6 +1282,7 @@ func (s *API) ServerAction(req *ServerActionRequest, opts ...scw.RequestOption) 
 		Path:    "/instance/v1/zones/" + fmt.Sprint(req.Zone) + "/servers/" + fmt.Sprint(req.ServerID) + "/action",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -1291,7 +1310,8 @@ func (s *API) ListServerUserData(req *ListServerUserDataRequest, opts ...scw.Req
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1324,7 +1344,8 @@ func (s *API) DeleteServerUserData(req *DeleteServerUserDataRequest, opts ...scw
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1357,7 +1378,8 @@ func (s *API) SetServerUserData(req *SetServerUserDataRequest, opts ...scw.Reque
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1365,6 +1387,7 @@ func (s *API) SetServerUserData(req *SetServerUserDataRequest, opts ...scw.Reque
 		Path:    "/instance/v1/zones/" + fmt.Sprint(req.Zone) + "/servers/" + fmt.Sprint(req.ServerID) + "/user_data/" + fmt.Sprint(req.Key) + "",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req.Content)
 	if err != nil {
 		return err
@@ -1392,7 +1415,8 @@ func (s *API) GetServerUserData(req *GetServerUserDataRequest, opts ...scw.Reque
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1432,14 +1456,16 @@ type ListImagesRequest struct {
 func (s *API) ListImages(req *ListImagesRequest, opts ...scw.RequestOption) (*ListImagesResponse, error) {
 	var err error
 
-	val := s.client.GetDefaultOrganizationID()
-	if (req.Organization == nil || *req.Organization == "") && string(val) != "" {
-		req.Organization = &val
+	defaultOrganization, exist := s.client.GetDefaultOrganizationID()
+	if (req.Organization == nil || *req.Organization == "") && exist {
+		req.Organization = &defaultOrganization
 	}
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
+
 	query := url.Values{}
 	parameter.AddToQuery(query, "organization", req.Organization)
 	parameter.AddToQuery(query, "per_page", req.PerPage)
@@ -1477,7 +1503,8 @@ func (s *API) GetImage(req *GetImageRequest, opts ...scw.RequestOption) (*GetIma
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1516,11 +1543,13 @@ func (s *API) CreateImage(req *CreateImageRequest, opts ...scw.RequestOption) (*
 	var err error
 
 	if req.Organization == "" {
-		req.Organization = s.client.GetDefaultOrganizationID()
+		defaultOrganization, _ := s.client.GetDefaultOrganizationID()
+		req.Organization = defaultOrganization
 	}
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1528,6 +1557,7 @@ func (s *API) CreateImage(req *CreateImageRequest, opts ...scw.RequestOption) (*
 		Path:    "/instance/v1/zones/" + fmt.Sprint(req.Zone) + "/images",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -1577,11 +1607,13 @@ func (s *API) SetImage(req *SetImageRequest, opts ...scw.RequestOption) (*SetIma
 	var err error
 
 	if req.Organization == "" {
-		req.Organization = s.client.GetDefaultOrganizationID()
+		defaultOrganization, _ := s.client.GetDefaultOrganizationID()
+		req.Organization = defaultOrganization
 	}
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1589,6 +1621,7 @@ func (s *API) SetImage(req *SetImageRequest, opts ...scw.RequestOption) (*SetIma
 		Path:    "/instance/v1/zones/" + fmt.Sprint(req.Zone) + "/images/" + fmt.Sprint(req.ID) + "",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -1616,7 +1649,8 @@ func (s *API) DeleteImage(req *DeleteImageRequest, opts ...scw.RequestOption) er
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1648,14 +1682,16 @@ type ListSnapshotsRequest struct {
 func (s *API) ListSnapshots(req *ListSnapshotsRequest, opts ...scw.RequestOption) (*ListSnapshotsResponse, error) {
 	var err error
 
-	val := s.client.GetDefaultOrganizationID()
-	if (req.Organization == nil || *req.Organization == "") && string(val) != "" {
-		req.Organization = &val
+	defaultOrganization, exist := s.client.GetDefaultOrganizationID()
+	if (req.Organization == nil || *req.Organization == "") && exist {
+		req.Organization = &defaultOrganization
 	}
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
+
 	query := url.Values{}
 	parameter.AddToQuery(query, "organization", req.Organization)
 	parameter.AddToQuery(query, "per_page", req.PerPage)
@@ -1693,11 +1729,13 @@ func (s *API) CreateSnapshot(req *CreateSnapshotRequest, opts ...scw.RequestOpti
 	var err error
 
 	if req.Organization == "" {
-		req.Organization = s.client.GetDefaultOrganizationID()
+		defaultOrganization, _ := s.client.GetDefaultOrganizationID()
+		req.Organization = defaultOrganization
 	}
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1705,6 +1743,7 @@ func (s *API) CreateSnapshot(req *CreateSnapshotRequest, opts ...scw.RequestOpti
 		Path:    "/instance/v1/zones/" + fmt.Sprint(req.Zone) + "/snapshots",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -1732,7 +1771,8 @@ func (s *API) GetSnapshot(req *GetSnapshotRequest, opts ...scw.RequestOption) (*
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1779,11 +1819,13 @@ func (s *API) SetSnapshot(req *SetSnapshotRequest, opts ...scw.RequestOption) (*
 	var err error
 
 	if req.Organization == "" {
-		req.Organization = s.client.GetDefaultOrganizationID()
+		defaultOrganization, _ := s.client.GetDefaultOrganizationID()
+		req.Organization = defaultOrganization
 	}
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1791,6 +1833,7 @@ func (s *API) SetSnapshot(req *SetSnapshotRequest, opts ...scw.RequestOption) (*
 		Path:    "/instance/v1/zones/" + fmt.Sprint(req.Zone) + "/snapshots/" + fmt.Sprint(req.ID) + "",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -1818,7 +1861,8 @@ func (s *API) DeleteSnapshot(req *DeleteSnapshotRequest, opts ...scw.RequestOpti
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1850,14 +1894,16 @@ type ListVolumesRequest struct {
 func (s *API) ListVolumes(req *ListVolumesRequest, opts ...scw.RequestOption) (*ListVolumesResponse, error) {
 	var err error
 
-	val := s.client.GetDefaultOrganizationID()
-	if (req.Organization == nil || *req.Organization == "") && string(val) != "" {
-		req.Organization = &val
+	defaultOrganization, exist := s.client.GetDefaultOrganizationID()
+	if (req.Organization == nil || *req.Organization == "") && exist {
+		req.Organization = &defaultOrganization
 	}
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
+
 	query := url.Values{}
 	parameter.AddToQuery(query, "organization", req.Organization)
 	parameter.AddToQuery(query, "per_page", req.PerPage)
@@ -1916,11 +1962,13 @@ func (s *API) CreateVolume(req *CreateVolumeRequest, opts ...scw.RequestOption) 
 	var err error
 
 	if req.Organization == "" {
-		req.Organization = s.client.GetDefaultOrganizationID()
+		defaultOrganization, _ := s.client.GetDefaultOrganizationID()
+		req.Organization = defaultOrganization
 	}
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1928,6 +1976,7 @@ func (s *API) CreateVolume(req *CreateVolumeRequest, opts ...scw.RequestOption) 
 		Path:    "/instance/v1/zones/" + fmt.Sprint(req.Zone) + "/volumes",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -1955,7 +2004,8 @@ func (s *API) GetVolume(req *GetVolumeRequest, opts ...scw.RequestOption) (*GetV
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -2004,11 +2054,13 @@ func (s *API) SetVolume(req *SetVolumeRequest, opts ...scw.RequestOption) (*SetV
 	var err error
 
 	if req.Organization == "" {
-		req.Organization = s.client.GetDefaultOrganizationID()
+		defaultOrganization, _ := s.client.GetDefaultOrganizationID()
+		req.Organization = defaultOrganization
 	}
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -2016,6 +2068,7 @@ func (s *API) SetVolume(req *SetVolumeRequest, opts ...scw.RequestOption) (*SetV
 		Path:    "/instance/v1/zones/" + fmt.Sprint(req.Zone) + "/volumes/" + fmt.Sprint(req.ID) + "",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -2043,7 +2096,8 @@ func (s *API) DeleteVolume(req *DeleteVolumeRequest, opts ...scw.RequestOption) 
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -2075,14 +2129,16 @@ type ListSecurityGroupsRequest struct {
 func (s *API) ListSecurityGroups(req *ListSecurityGroupsRequest, opts ...scw.RequestOption) (*ListSecurityGroupsResponse, error) {
 	var err error
 
-	val := s.client.GetDefaultOrganizationID()
-	if (req.Organization == nil || *req.Organization == "") && string(val) != "" {
-		req.Organization = &val
+	defaultOrganization, exist := s.client.GetDefaultOrganizationID()
+	if (req.Organization == nil || *req.Organization == "") && exist {
+		req.Organization = &defaultOrganization
 	}
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
+
 	query := url.Values{}
 	parameter.AddToQuery(query, "organization", req.Organization)
 	parameter.AddToQuery(query, "per_page", req.PerPage)
@@ -2125,7 +2181,8 @@ func (s *API) CreateSecurityGroup(req *CreateSecurityGroupRequest, opts ...scw.R
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -2133,6 +2190,7 @@ func (s *API) CreateSecurityGroup(req *CreateSecurityGroupRequest, opts ...scw.R
 		Path:    "/instance/v1/zones/" + fmt.Sprint(req.Zone) + "/security_groups",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -2160,7 +2218,8 @@ func (s *API) GetSecurityGroup(req *GetSecurityGroupRequest, opts ...scw.Request
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -2189,7 +2248,8 @@ func (s *API) DeleteSecurityGroup(req *DeleteSecurityGroupRequest, opts ...scw.R
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -2240,11 +2300,13 @@ func (s *API) SetSecurityGroup(req *SetSecurityGroupRequest, opts ...scw.Request
 	var err error
 
 	if req.Organization == "" {
-		req.Organization = s.client.GetDefaultOrganizationID()
+		defaultOrganization, _ := s.client.GetDefaultOrganizationID()
+		req.Organization = defaultOrganization
 	}
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -2252,6 +2314,7 @@ func (s *API) SetSecurityGroup(req *SetSecurityGroupRequest, opts ...scw.Request
 		Path:    "/instance/v1/zones/" + fmt.Sprint(req.Zone) + "/security_groups/" + fmt.Sprint(req.ID) + "",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -2281,8 +2344,10 @@ func (s *API) ListSecurityGroupRules(req *ListSecurityGroupRulesRequest, opts ..
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
+
 	query := url.Values{}
 	parameter.AddToQuery(query, "per_page", req.PerPage)
 	parameter.AddToQuery(query, "page", req.Page)
@@ -2330,7 +2395,8 @@ func (s *API) CreateSecurityGroupRule(req *CreateSecurityGroupRuleRequest, opts 
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -2338,6 +2404,7 @@ func (s *API) CreateSecurityGroupRule(req *CreateSecurityGroupRuleRequest, opts 
 		Path:    "/instance/v1/zones/" + fmt.Sprint(req.Zone) + "/security_groups/" + fmt.Sprint(req.SecurityGroupID) + "/rules",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -2367,7 +2434,8 @@ func (s *API) DeleteSecurityGroupRule(req *DeleteSecurityGroupRuleRequest, opts 
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -2398,7 +2466,8 @@ func (s *API) GetSecurityGroupRule(req *GetSecurityGroupRuleRequest, opts ...scw
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -2429,12 +2498,15 @@ func (s *API) ListIps(req *ListIpsRequest, opts ...scw.RequestOption) (*ListIpsR
 	var err error
 
 	if req.Organization == "" {
-		req.Organization = s.client.GetDefaultOrganizationID()
+		defaultOrganization, _ := s.client.GetDefaultOrganizationID()
+		req.Organization = defaultOrganization
 	}
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
+
 	query := url.Values{}
 	parameter.AddToQuery(query, "organization", req.Organization)
 	parameter.AddToQuery(query, "name", req.Name)
@@ -2468,11 +2540,13 @@ func (s *API) CreateIP(req *CreateIPRequest, opts ...scw.RequestOption) (*Create
 	var err error
 
 	if req.Organization == "" {
-		req.Organization = s.client.GetDefaultOrganizationID()
+		defaultOrganization, _ := s.client.GetDefaultOrganizationID()
+		req.Organization = defaultOrganization
 	}
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -2480,6 +2554,7 @@ func (s *API) CreateIP(req *CreateIPRequest, opts ...scw.RequestOption) (*Create
 		Path:    "/instance/v1/zones/" + fmt.Sprint(req.Zone) + "/ips",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -2507,7 +2582,8 @@ func (s *API) GetIP(req *GetIPRequest, opts ...scw.RequestOption) (*GetIPRespons
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -2543,11 +2619,13 @@ func (s *API) SetIP(req *SetIPRequest, opts ...scw.RequestOption) (*SetIPRespons
 	var err error
 
 	if req.Organization == "" {
-		req.Organization = s.client.GetDefaultOrganizationID()
+		defaultOrganization, _ := s.client.GetDefaultOrganizationID()
+		req.Organization = defaultOrganization
 	}
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -2555,6 +2633,7 @@ func (s *API) SetIP(req *SetIPRequest, opts ...scw.RequestOption) (*SetIPRespons
 		Path:    "/instance/v1/zones/" + fmt.Sprint(req.Zone) + "/ips/" + fmt.Sprint(req.ID) + "",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -2584,7 +2663,8 @@ func (s *API) updateIP(req *updateIPRequest, opts ...scw.RequestOption) (*Update
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -2592,6 +2672,7 @@ func (s *API) updateIP(req *updateIPRequest, opts ...scw.RequestOption) (*Update
 		Path:    "/instance/v1/zones/" + fmt.Sprint(req.Zone) + "/ips/" + fmt.Sprint(req.IPID) + "",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -2619,7 +2700,8 @@ func (s *API) DeleteIP(req *DeleteIPRequest, opts ...scw.RequestOption) error {
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -2652,8 +2734,10 @@ func (s *API) ListBootscripts(req *ListBootscriptsRequest, opts ...scw.RequestOp
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
+
 	query := url.Values{}
 	parameter.AddToQuery(query, "arch", req.Arch)
 	parameter.AddToQuery(query, "title", req.Title)
@@ -2689,7 +2773,8 @@ func (s *API) GetBootscript(req *GetBootscriptRequest, opts ...scw.RequestOption
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -2715,7 +2800,8 @@ func (s *API) GetServiceInfo(req *GetServiceInfoRequest, opts ...scw.RequestOpti
 	var err error
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -2742,14 +2828,16 @@ type GetDashboardRequest struct {
 func (s *API) GetDashboard(req *GetDashboardRequest, opts ...scw.RequestOption) (*GetDashboardResponse, error) {
 	var err error
 
-	val := s.client.GetDefaultOrganizationID()
-	if (req.Organization == nil || *req.Organization == "") && string(val) != "" {
-		req.Organization = &val
+	defaultOrganization, exist := s.client.GetDefaultOrganizationID()
+	if (req.Organization == nil || *req.Organization == "") && exist {
+		req.Organization = &defaultOrganization
 	}
 
 	if req.Zone == "" {
-		req.Zone = s.client.GetDefaultZone()
+		defaultZone, _ := s.client.GetDefaultZone()
+		req.Zone = defaultZone
 	}
+
 	query := url.Values{}
 	parameter.AddToQuery(query, "organization", req.Organization)
 

--- a/api/lb/v1/lb_sdk.go
+++ b/api/lb/v1/lb_sdk.go
@@ -717,7 +717,8 @@ func (s *API) GetServiceInfo(req *GetServiceInfoRequest, opts ...scw.RequestOpti
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -752,13 +753,14 @@ type ListLbsRequest struct {
 func (s *API) ListLbs(req *ListLbsRequest, opts ...scw.RequestOption) (*ListLbsResponse, error) {
 	var err error
 
-	val := s.client.GetDefaultOrganizationID()
-	if (req.OrganizationID == nil || *req.OrganizationID == "") && string(val) != "" {
-		req.OrganizationID = &val
+	defaultOrganizationID, exist := s.client.GetDefaultOrganizationID()
+	if (req.OrganizationID == nil || *req.OrganizationID == "") && exist {
+		req.OrganizationID = &defaultOrganizationID
 	}
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	query := url.Values{}
@@ -802,11 +804,13 @@ func (s *API) CreateLb(req *CreateLbRequest, opts ...scw.RequestOption) (*Lb, er
 	var err error
 
 	if req.OrganizationID == "" {
-		req.OrganizationID = s.client.GetDefaultOrganizationID()
+		defaultOrganizationID, _ := s.client.GetDefaultOrganizationID()
+		req.OrganizationID = defaultOrganizationID
 	}
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -814,6 +818,7 @@ func (s *API) CreateLb(req *CreateLbRequest, opts ...scw.RequestOption) (*Lb, er
 		Path:    "/lb/v1/regions/" + fmt.Sprint(req.Region) + "/lbs",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -838,7 +843,8 @@ func (s *API) GetLb(req *GetLbRequest, opts ...scw.RequestOption) (*Lb, error) {
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -872,7 +878,8 @@ func (s *API) UpdateLb(req *UpdateLbRequest, opts ...scw.RequestOption) (*Lb, er
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -880,6 +887,7 @@ func (s *API) UpdateLb(req *UpdateLbRequest, opts ...scw.RequestOption) (*Lb, er
 		Path:    "/lb/v1/regions/" + fmt.Sprint(req.Region) + "/lbs/" + fmt.Sprint(req.LbID) + "",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -906,7 +914,8 @@ func (s *API) DeleteLb(req *DeleteLbRequest, opts ...scw.RequestOption) error {
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	query := url.Values{}
@@ -942,13 +951,14 @@ type ListIPsRequest struct {
 func (s *API) ListIPs(req *ListIPsRequest, opts ...scw.RequestOption) (*ListIpsResponse, error) {
 	var err error
 
-	val := s.client.GetDefaultOrganizationID()
-	if (req.OrganizationID == nil || *req.OrganizationID == "") && string(val) != "" {
-		req.OrganizationID = &val
+	defaultOrganizationID, exist := s.client.GetDefaultOrganizationID()
+	if (req.OrganizationID == nil || *req.OrganizationID == "") && exist {
+		req.OrganizationID = &defaultOrganizationID
 	}
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	query := url.Values{}
@@ -986,7 +996,8 @@ func (s *API) GetIP(req *GetIPRequest, opts ...scw.RequestOption) (*IP, error) {
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1015,7 +1026,8 @@ func (s *API) ReleaseIP(req *ReleaseIPRequest, opts ...scw.RequestOption) error 
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1043,7 +1055,8 @@ func (s *API) UpdateIP(req *UpdateIPRequest, opts ...scw.RequestOption) (*IP, er
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	query := url.Values{}
@@ -1083,7 +1096,8 @@ func (s *API) ListBackends(req *ListBackendsRequest, opts ...scw.RequestOption) 
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	query := url.Values{}
@@ -1184,7 +1198,8 @@ func (s *API) CreateBackend(req *CreateBackendRequest, opts ...scw.RequestOption
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1192,6 +1207,7 @@ func (s *API) CreateBackend(req *CreateBackendRequest, opts ...scw.RequestOption
 		Path:    "/lb/v1/regions/" + fmt.Sprint(req.Region) + "/lbs/" + fmt.Sprint(req.LbID) + "/backends",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -1216,7 +1232,8 @@ func (s *API) GetBackend(req *GetBackendRequest, opts ...scw.RequestOption) (*Ba
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1306,7 +1323,8 @@ func (s *API) UpdateBackend(req *UpdateBackendRequest, opts ...scw.RequestOption
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1314,6 +1332,7 @@ func (s *API) UpdateBackend(req *UpdateBackendRequest, opts ...scw.RequestOption
 		Path:    "/lb/v1/regions/" + fmt.Sprint(req.Region) + "/backends/" + fmt.Sprint(req.BackendID) + "",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -1338,7 +1357,8 @@ func (s *API) DeleteBackend(req *DeleteBackendRequest, opts ...scw.RequestOption
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1366,7 +1386,8 @@ func (s *API) AddBackendServers(req *AddBackendServersRequest, opts ...scw.Reque
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1374,6 +1395,7 @@ func (s *API) AddBackendServers(req *AddBackendServersRequest, opts ...scw.Reque
 		Path:    "/lb/v1/regions/" + fmt.Sprint(req.Region) + "/backends/" + fmt.Sprint(req.BackendID) + "/servers",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -1400,7 +1422,8 @@ func (s *API) RemoveBackendServers(req *RemoveBackendServersRequest, opts ...scw
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1408,6 +1431,7 @@ func (s *API) RemoveBackendServers(req *RemoveBackendServersRequest, opts ...scw
 		Path:    "/lb/v1/regions/" + fmt.Sprint(req.Region) + "/backends/" + fmt.Sprint(req.BackendID) + "/servers",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -1434,7 +1458,8 @@ func (s *API) SetBackendServers(req *SetBackendServersRequest, opts ...scw.Reque
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1442,6 +1467,7 @@ func (s *API) SetBackendServers(req *SetBackendServersRequest, opts ...scw.Reque
 		Path:    "/lb/v1/regions/" + fmt.Sprint(req.Region) + "/backends/" + fmt.Sprint(req.BackendID) + "/servers",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -1551,7 +1577,8 @@ func (s *API) UpdateHealthCheck(req *UpdateHealthCheckRequest, opts ...scw.Reque
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1559,6 +1586,7 @@ func (s *API) UpdateHealthCheck(req *UpdateHealthCheckRequest, opts ...scw.Reque
 		Path:    "/lb/v1/regions/" + fmt.Sprint(req.Region) + "/backends/" + fmt.Sprint(req.BackendID) + "/healthcheck",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -1591,7 +1619,8 @@ func (s *API) ListFrontends(req *ListFrontendsRequest, opts ...scw.RequestOption
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	query := url.Values{}
@@ -1666,7 +1695,8 @@ func (s *API) CreateFrontend(req *CreateFrontendRequest, opts ...scw.RequestOpti
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1674,6 +1704,7 @@ func (s *API) CreateFrontend(req *CreateFrontendRequest, opts ...scw.RequestOpti
 		Path:    "/lb/v1/regions/" + fmt.Sprint(req.Region) + "/lbs/" + fmt.Sprint(req.LbID) + "/frontends",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -1698,7 +1729,8 @@ func (s *API) GetFrontend(req *GetFrontendRequest, opts ...scw.RequestOption) (*
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1766,7 +1798,8 @@ func (s *API) UpdateFrontend(req *UpdateFrontendRequest, opts ...scw.RequestOpti
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1774,6 +1807,7 @@ func (s *API) UpdateFrontend(req *UpdateFrontendRequest, opts ...scw.RequestOpti
 		Path:    "/lb/v1/regions/" + fmt.Sprint(req.Region) + "/frontends/" + fmt.Sprint(req.FrontendID) + "",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -1798,7 +1832,8 @@ func (s *API) DeleteFrontend(req *DeleteFrontendRequest, opts ...scw.RequestOpti
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1824,7 +1859,8 @@ func (s *API) GetLbStats(req *GetLbStatsRequest, opts ...scw.RequestOption) (*Lb
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1860,7 +1896,8 @@ func (s *API) ListAcls(req *ListAclsRequest, opts ...scw.RequestOption) (*ListAC
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	query := url.Values{}
@@ -1903,7 +1940,8 @@ func (s *API) CreateACL(req *CreateACLRequest, opts ...scw.RequestOption) (*ACL,
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1911,6 +1949,7 @@ func (s *API) CreateACL(req *CreateACLRequest, opts ...scw.RequestOption) (*ACL,
 		Path:    "/lb/v1/regions/" + fmt.Sprint(req.Region) + "/frontends/" + fmt.Sprint(req.FrontendID) + "/acls",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -1935,7 +1974,8 @@ func (s *API) GetACL(req *GetACLRequest, opts ...scw.RequestOption) (*ACL, error
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1971,7 +2011,8 @@ func (s *API) UpdateACL(req *UpdateACLRequest, opts ...scw.RequestOption) (*ACL,
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{
@@ -1979,6 +2020,7 @@ func (s *API) UpdateACL(req *UpdateACLRequest, opts ...scw.RequestOption) (*ACL,
 		Path:    "/lb/v1/regions/" + fmt.Sprint(req.Region) + "/acls/" + fmt.Sprint(req.ACLID) + "",
 		Headers: http.Header{},
 	}
+
 	err = scwReq.SetBody(req)
 	if err != nil {
 		return nil, err
@@ -2003,7 +2045,8 @@ func (s *API) DeleteACL(req *DeleteACLRequest, opts ...scw.RequestOption) error 
 	var err error
 
 	if req.Region == "" {
-		req.Region = s.client.GetDefaultRegion()
+		defaultRegion, _ := s.client.GetDefaultRegion()
+		req.Region = defaultRegion
 	}
 
 	scwReq := &scw.ScalewayRequest{

--- a/scw/client.go
+++ b/scw/client.go
@@ -23,9 +23,9 @@ type Client struct {
 	auth                  auth.Auth
 	apiURL                string
 	userAgent             string
-	defaultOrganizationID string
-	defaultRegion         utils.Region
-	defaultZone           utils.Zone
+	defaultOrganizationID *string
+	defaultRegion         *utils.Region
+	defaultZone           *utils.Zone
 }
 
 // NewClient instantiates a new Client object.
@@ -69,24 +69,24 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 }
 
 // GetDefaultOrganizationID return the default organization ID
-// of the client. This value can be set from the client option
+// of the client. This value can be set in the client option
 // WithDefaultOrganizationID(). Be aware this value can be empty.
-func (c *Client) GetDefaultOrganizationID() string {
-	return c.defaultOrganizationID
+func (c *Client) GetDefaultOrganizationID() (string, bool) {
+	return *c.defaultOrganizationID, c.defaultOrganizationID != nil
 }
 
 // GetDefaultRegion return the default region of the client.
-// This value can be set from the client option
+// This value can be set in the client option
 // WithDefaultRegion(). Be aware this value can be empty.
-func (c *Client) GetDefaultRegion() utils.Region {
-	return c.defaultRegion
+func (c *Client) GetDefaultRegion() (utils.Region, bool) {
+	return *c.defaultRegion, c.defaultRegion != nil
 }
 
 // GetDefaultZone return the default zone of the client.
-// This value can be set from the client option
+// This value can be set in the client option
 // WithDefaultZone(). Be aware this value can be empty.
-func (c *Client) GetDefaultZone() utils.Zone {
-	return c.defaultZone
+func (c *Client) GetDefaultZone() (utils.Zone, bool) {
+	return *c.defaultZone, c.defaultZone != nil
 }
 
 // Do performs an HTTP request based on the ScalewayRequest object.

--- a/scw/client.go
+++ b/scw/client.go
@@ -72,21 +72,30 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 // of the client. This value can be set in the client option
 // WithDefaultOrganizationID(). Be aware this value can be empty.
 func (c *Client) GetDefaultOrganizationID() (string, bool) {
-	return *c.defaultOrganizationID, c.defaultOrganizationID != nil
+	if c.defaultOrganizationID != nil {
+		return *c.defaultOrganizationID, true
+	}
+	return "", false
 }
 
 // GetDefaultRegion return the default region of the client.
 // This value can be set in the client option
 // WithDefaultRegion(). Be aware this value can be empty.
 func (c *Client) GetDefaultRegion() (utils.Region, bool) {
-	return *c.defaultRegion, c.defaultRegion != nil
+	if c.defaultRegion != nil {
+		return *c.defaultRegion, true
+	}
+	return utils.Region(""), false
 }
 
 // GetDefaultZone return the default zone of the client.
 // This value can be set in the client option
 // WithDefaultZone(). Be aware this value can be empty.
 func (c *Client) GetDefaultZone() (utils.Zone, bool) {
-	return *c.defaultZone, c.defaultZone != nil
+	if c.defaultZone != nil {
+		return *c.defaultZone, true
+	}
+	return utils.Zone(""), false
 }
 
 // Do performs an HTTP request based on the ScalewayRequest object.

--- a/scw/client_option.go
+++ b/scw/client_option.go
@@ -80,17 +80,17 @@ func WithConfig(config scwconfig.Config) ClientOption {
 
 		defaultOrganizationID, exist := config.GetDefaultOrganizationID()
 		if exist {
-			s.defaultOrganizationID = defaultOrganizationID
+			s.defaultOrganizationID = &defaultOrganizationID
 		}
 
 		defaultRegion, exist := config.GetDefaultRegion()
 		if exist {
-			s.defaultRegion = defaultRegion
+			s.defaultRegion = &defaultRegion
 		}
 
 		defaultZone, exist := config.GetDefaultZone()
 		if exist {
-			s.defaultZone = defaultZone
+			s.defaultZone = &defaultZone
 		}
 	}
 }
@@ -100,7 +100,7 @@ func WithConfig(config scwconfig.Config) ClientOption {
 // It will be used as the default value of the organization_id field in all requests made with this client.
 func WithDefaultOrganizationID(organizationID string) ClientOption {
 	return func(s *settings) {
-		s.defaultOrganizationID = organizationID
+		s.defaultOrganizationID = &organizationID
 	}
 }
 
@@ -109,7 +109,7 @@ func WithDefaultOrganizationID(organizationID string) ClientOption {
 // It will be used as the default value of the region field in all requests made with this client.
 func WithDefaultRegion(region utils.Region) ClientOption {
 	return func(s *settings) {
-		s.defaultRegion = region
+		s.defaultRegion = &region
 	}
 }
 
@@ -118,6 +118,6 @@ func WithDefaultRegion(region utils.Region) ClientOption {
 // It will be used as the default value of the zone field in all requests made with this client.
 func WithDefaultZone(zone utils.Zone) ClientOption {
 	return func(s *settings) {
-		s.defaultZone = zone
+		s.defaultZone = &zone
 	}
 }

--- a/scw/client_test.go
+++ b/scw/client_test.go
@@ -85,9 +85,17 @@ func TestNewClientWithOptions(t *testing.T) {
 
 		testhelpers.Equals(t, someHTTPClient, client.httpClient)
 
-		testhelpers.Equals(t, testDefaultOrganizationID, client.GetDefaultOrganizationID())
-		testhelpers.Equals(t, testDefaultRegion, client.GetDefaultRegion())
-		testhelpers.Equals(t, testDefaultZone, client.GetDefaultZone())
+		defaultOrganizationID, exist := client.GetDefaultOrganizationID()
+		testhelpers.Equals(t, testDefaultOrganizationID, defaultOrganizationID)
+		testhelpers.Assert(t, exist, "defaultOrganizationID must exist")
+
+		defaultRegion, exist := client.GetDefaultRegion()
+		testhelpers.Equals(t, testDefaultRegion, defaultRegion)
+		testhelpers.Assert(t, exist, "defaultRegion must exist")
+
+		defaultZone, exist := client.GetDefaultZone()
+		testhelpers.Equals(t, testDefaultZone, defaultZone)
+		testhelpers.Assert(t, exist, "defaultZone must exist")
 	})
 
 	t.Run("With scwconfig", func(t *testing.T) {
@@ -104,9 +112,17 @@ func TestNewClientWithOptions(t *testing.T) {
 		testhelpers.Assert(t, clientTransport.TLSClientConfig != nil, "TLSClientConfig must be not nil")
 		testhelpers.Equals(t, testInsecure, clientTransport.TLSClientConfig.InsecureSkipVerify)
 
-		testhelpers.Equals(t, testDefaultOrganizationID, client.GetDefaultOrganizationID())
-		testhelpers.Equals(t, testDefaultRegion, client.GetDefaultRegion())
-		testhelpers.Equals(t, testDefaultZone, client.GetDefaultZone())
+		defaultOrganizationID, exist := client.GetDefaultOrganizationID()
+		testhelpers.Equals(t, testDefaultOrganizationID, defaultOrganizationID)
+		testhelpers.Assert(t, exist, "defaultOrganizationID must exist")
+
+		defaultRegion, exist := client.GetDefaultRegion()
+		testhelpers.Equals(t, testDefaultRegion, defaultRegion)
+		testhelpers.Assert(t, exist, "defaultRegion must exist")
+
+		defaultZone, exist := client.GetDefaultZone()
+		testhelpers.Equals(t, testDefaultZone, defaultZone)
+		testhelpers.Assert(t, exist, "defaultZone must exist")
 	})
 
 }

--- a/scw/settings.go
+++ b/scw/settings.go
@@ -45,10 +45,12 @@ func (s *settings) validate() error {
 		return fmt.Errorf("default organization id cannot be empty")
 	}
 
+	// TODO: Check Region format
 	if s.defaultRegion != nil && *s.defaultRegion == "" {
 		return fmt.Errorf("default region cannot be empty")
 	}
 
+	// TODO: Check Zone format
 	if s.defaultZone != nil && *s.defaultZone == "" {
 		return fmt.Errorf("default zone cannot be empty")
 	}

--- a/scw/settings.go
+++ b/scw/settings.go
@@ -14,9 +14,9 @@ type settings struct {
 	userAgent             string
 	httpClient            httpClient
 	insecure              bool
-	defaultOrganizationID string
-	defaultRegion         utils.Region
-	defaultZone           utils.Zone
+	defaultOrganizationID *string
+	defaultRegion         *utils.Region
+	defaultZone           *utils.Zone
 }
 
 func newSettings() *settings {
@@ -27,7 +27,6 @@ func (s *settings) apply(opts []ClientOption) {
 	for _, opt := range opts {
 		opt(s)
 	}
-
 }
 
 func (s *settings) validate() error {
@@ -39,6 +38,19 @@ func (s *settings) validate() error {
 	_, err = url.Parse(s.apiURL)
 	if err != nil {
 		return fmt.Errorf("invalid url %s: %s", s.apiURL, err)
+	}
+
+	// TODO: Check OrganizationID format
+	if s.defaultOrganizationID != nil && *s.defaultOrganizationID == "" {
+		return fmt.Errorf("default organization id cannot be empty")
+	}
+
+	if s.defaultRegion != nil && *s.defaultRegion == "" {
+		return fmt.Errorf("default region cannot be empty")
+	}
+
+	if s.defaultZone != nil && *s.defaultZone == "" {
+		return fmt.Errorf("default zone cannot be empty")
 	}
 
 	return nil


### PR DESCRIPTION
**This changes will break the public API.**

This PR refactor clients options getters. From now, they will return their values and a boolean that precise if the value has been set or not (with a `scw.WithDefaultSomething()`).

```golang
--- func (c *Client) GetDefaultOrganizationID() string
+++ func (c *Client) GetDefaultOrganizationID() (string, bool)

--- func (c *Client) GetDefaultRegion() utils.Region
+++ func (c *Client) GetDefaultRegion() (utils.Region, bool)

--- func (c *Client) GetDefaultZone() utils.Zone
+++ func (c *Client) GetDefaultZone() (utils.Zone, bool)
```