### PR TITLE
feat(baremetal): fix WaitForServer and add WaitForServerInstall

### DIFF
--- a/api/baremetal/v1alpha1/server_utils.go
+++ b/api/baremetal/v1alpha1/server_utils.go
@@ -20,17 +20,15 @@ type WaitForServerRequest struct {
 func (s *API) WaitForServer(req *WaitForServerRequest) (*Server, scw.SdkError) {
 
 	terminalStatus := map[ServerStatus]struct{}{
-		ServerStatusReady:       {},
-		ServerStatusStopped:     {},
-		ServerStatusError:       {},
-		ServerStatusUndelivered: {},
-		ServerStatusLocked:      {},
-		ServerStatusUnknown:     {},
+		ServerStatusReady:   {},
+		ServerStatusStopped: {},
+		ServerStatusError:   {},
+		ServerStatusLocked:  {},
+		ServerStatusUnknown: {},
 	}
 
 	installTerminalStatus := map[ServerInstallStatus]struct{}{
 		ServerInstallStatusCompleted: {},
-		ServerInstallStatusToInstall: {},
 		ServerInstallStatusError:     {},
 		ServerInstallStatusUnknown:   {},
 	}
@@ -53,7 +51,9 @@ func (s *API) WaitForServer(req *WaitForServerRequest) (*Server, scw.SdkError) {
 
 			return res, err, isTerminal && isTerminalInstall
 		},
-		Timeout:          req.Timeout,
+		Timeout: req.Timeout,
+		// TODO: Install is a long process, we should increase the
+		// interval when isTerminalInstall == true.
 		IntervalStrategy: async.LinearIntervalStrategy(5 * time.Second),
 	})
 	if err != nil {

--- a/api/baremetal/v1alpha1/server_utils.go
+++ b/api/baremetal/v1alpha1/server_utils.go
@@ -16,7 +16,7 @@ type WaitForServerRequest struct {
 }
 
 // WaitForServer wait for the server to be in a "terminal state" before returning.
-// This function can be used to wait for a server to be installed.
+// This function can be used to wait for a server to be created.
 func (s *API) WaitForServer(req *WaitForServerRequest) (*Server, scw.SdkError) {
 	terminalStatus := map[ServerStatus]struct{}{
 		ServerStatusReady:   {},
@@ -87,7 +87,7 @@ func (s *API) WaitForServerInstall(req *WaitForServerInstallRequest) (*Server, s
 		IntervalStrategy: async.LinearIntervalStrategy(15 * time.Second),
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "waiting for server failed")
+		return nil, errors.Wrap(err, "waiting for server installation failed")
 	}
 
 	return server.(*Server), nil

--- a/api/baremetal/v1alpha1/server_utils.go
+++ b/api/baremetal/v1alpha1/server_utils.go
@@ -8,7 +8,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 
-// WaitForServerRequest is used by WaitForServer method
+// WaitForServerRequest is used by WaitForServer method.
 type WaitForServerRequest struct {
 	ServerID string
 	Zone     scw.Zone
@@ -16,9 +16,8 @@ type WaitForServerRequest struct {
 }
 
 // WaitForServer wait for the server to be in a "terminal state" before returning.
-// This function can be used to wait for a server to be installed for example.
+// This function can be used to wait for a server to be installed.
 func (s *API) WaitForServer(req *WaitForServerRequest) (*Server, scw.SdkError) {
-
 	terminalStatus := map[ServerStatus]struct{}{
 		ServerStatusReady:   {},
 		ServerStatusStopped: {},
@@ -27,6 +26,40 @@ func (s *API) WaitForServer(req *WaitForServerRequest) (*Server, scw.SdkError) {
 		ServerStatusUnknown: {},
 	}
 
+	server, err := async.WaitSync(&async.WaitSyncConfig{
+		Get: func() (interface{}, error, bool) {
+			res, err := s.GetServer(&GetServerRequest{
+				ServerID: req.ServerID,
+				Zone:     req.Zone,
+			})
+			if err != nil {
+				return nil, err, false
+			}
+
+			_, isTerminal := terminalStatus[res.Status]
+			return res, err, isTerminal
+		},
+		Timeout:          req.Timeout,
+		IntervalStrategy: async.LinearIntervalStrategy(5 * time.Second),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "waiting for server failed")
+	}
+
+	return server.(*Server), nil
+}
+
+// WaitForServerInstallRequest is used by WaitForServerInstall method.
+type WaitForServerInstallRequest struct {
+	ServerID string
+	Zone     scw.Zone
+	Timeout  time.Duration
+}
+
+// WaitForServerInstall wait for the server install to be in a
+// "terminal state" before returning.
+// This function can be used to wait for a server to be installed.
+func (s *API) WaitForServerInstall(req *WaitForServerInstallRequest) (*Server, scw.SdkError) {
 	installTerminalStatus := map[ServerInstallStatus]struct{}{
 		ServerInstallStatusCompleted: {},
 		ServerInstallStatusError:     {},
@@ -39,22 +72,19 @@ func (s *API) WaitForServer(req *WaitForServerRequest) (*Server, scw.SdkError) {
 				ServerID: req.ServerID,
 				Zone:     req.Zone,
 			})
-
 			if err != nil {
 				return nil, err, false
 			}
-			_, isTerminal := terminalStatus[res.Status]
-			isTerminalInstall := true
-			if res.Install != nil {
-				_, isTerminalInstall = installTerminalStatus[res.Install.Status]
+
+			if res.Install == nil {
+				return nil, errors.New("server creation has not begun for server %s", req.ServerID), false
 			}
 
-			return res, err, isTerminal && isTerminalInstall
+			_, isTerminal := installTerminalStatus[res.Install.Status]
+			return res, err, isTerminal
 		},
-		Timeout: req.Timeout,
-		// TODO: Install is a long process, we should increase the
-		// interval when isTerminalInstall == true.
-		IntervalStrategy: async.LinearIntervalStrategy(5 * time.Second),
+		Timeout:          req.Timeout,
+		IntervalStrategy: async.LinearIntervalStrategy(15 * time.Second),
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "waiting for server failed")


### PR DESCRIPTION
Split `WaitForServer` into two methods:

- `WaitForServer`: waits for server creation.
- `WaitForServerInstall` waits for server installation.

Fix status:
- `ServerStatusUndelivered` means "delivering" so it is not a terminal state.
- `ServerInstallStatusToInstall` means "ready to start an installation" so it is not a terminal state either.