### PR TITLE
feat(core): support more instance error types

### DIFF
--- a/scw/errors.go
+++ b/scw/errors.go
@@ -160,7 +160,7 @@ func unmarshalNonStandardError(errorType string, body []byte) error {
 			return invalidArgumentsError
 		}
 
-		// At this point, the `invalid_request_error` is not an InvalidArgumentsError and
+		// At this point, the invalid_request_error is not an InvalidArgumentsError and
 		// the default marshalling will be used.
 		return nil
 
@@ -220,29 +220,29 @@ type InvalidRequestError struct {
 
 // ToSdkError returns a standard error InvalidArgumentsError or nil Fields is nil.
 func (e *InvalidRequestError) ToInvalidArgumentsError() SdkError {
-	// If error has fields, it is an invalid arguments error.
-	if e.Fields != nil {
-		invalidArguments := &InvalidArgumentsError{
-			RawBody: e.RawBody,
-		}
-		fieldNames := []string(nil)
-		for fieldName := range e.Fields {
-			fieldNames = append(fieldNames, fieldName)
-		}
-		sort.Strings(fieldNames)
-		for _, fieldName := range fieldNames {
-			for _, message := range e.Fields[fieldName] {
-				invalidArguments.Details = append(invalidArguments.Details, InvalidArgumentsErrorDetail{
-					ArgumentName: fieldName,
-					Reason:       "constraint",
-					HelpMessage:  message,
-				})
-			}
-		}
-		return invalidArguments
+	// If error has no fields, it is not an InvalidArgumentsError.
+	if e.Fields == nil {
+		return nil
 	}
 
-	return nil
+	invalidArguments := &InvalidArgumentsError{
+		RawBody: e.RawBody,
+	}
+	fieldNames := []string(nil)
+	for fieldName := range e.Fields {
+		fieldNames = append(fieldNames, fieldName)
+	}
+	sort.Strings(fieldNames)
+	for _, fieldName := range fieldNames {
+		for _, message := range e.Fields[fieldName] {
+			invalidArguments.Details = append(invalidArguments.Details, InvalidArgumentsErrorDetail{
+				ArgumentName: fieldName,
+				Reason:       "constraint",
+				HelpMessage:  message,
+			})
+		}
+	}
+	return invalidArguments
 }
 
 type QuotasExceededError struct {

--- a/scw/errors_test.go
+++ b/scw/errors_test.go
@@ -30,7 +30,6 @@ func TestHasResponseErrorWithoutBody(t *testing.T) {
 }
 
 func TestNonStandardError(t *testing.T) {
-
 	type testCase struct {
 		resStatus     string
 		resStatusCode int
@@ -79,9 +78,11 @@ func TestNonStandardError(t *testing.T) {
 		resStatusCode: http.StatusBadRequest,
 		resBody:       `{"message": "server should be running", "type": "invalid_request_error"}`,
 		expectedError: &ResponseError{
-			Message: "server should be running",
-			Type:    "invalid_request_error",
-			RawBody: []byte(`{"message": "server should be running", "type": "invalid_request_error"}`),
+			Status:     "400 Bad Request",
+			StatusCode: http.StatusBadRequest,
+			Message:    "server should be running",
+			Type:       "invalid_request_error",
+			RawBody:    []byte(`{"message": "server should be running", "type": "invalid_request_error"}`),
 		},
 	}))
 
@@ -90,9 +91,11 @@ func TestNonStandardError(t *testing.T) {
 		resStatusCode: http.StatusConflict,
 		resBody:       `{"message": "Group is in use. You cannot delete it.", "type": "conflict"}`,
 		expectedError: &ResponseError{
-			Message: "group is in use. you cannot delete it.",
-			Type:    "conflict",
-			RawBody: []byte(`{"message": "Group is in use. You cannot delete it.", "type": "conflict"}`),
+			Status:     "409 Conflict",
+			StatusCode: http.StatusConflict,
+			Message:    "group is in use. you cannot delete it.",
+			Type:       "conflict",
+			RawBody:    []byte(`{"message": "Group is in use. You cannot delete it.", "type": "conflict"}`),
 		},
 	}))
 }


### PR DESCRIPTION
Converssions:
* Error type `invalid_request_error` with `fields` field => `InvalidArgumentsError`
* Error type `invalid_request_error` without `fields` field and with `message` field => `ResponseError`
* Error type `conflict` => `ResponseError`

See `errors_test.go` for more details.