### PR TITLE
chore: remove go 1.10 and 1.11 from gh action

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -7,7 +7,7 @@ jobs:
   unit-test:
     strategy:
       matrix:
-        go-version: [1.12.x, 1.13.x, 1.x.x]
+        go-version: [1.12.x, 1.13.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -7,7 +7,7 @@ jobs:
   unit-test:
     strategy:
       matrix:
-        go-version: [1.12.x, 1.13.x, tip]
+        go-version: [1.12.x, 1.13.x, 1.x.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -7,7 +7,7 @@ jobs:
   unit-test:
     strategy:
       matrix:
-        go-version: [1.10.x, 1.11.x, 1.12.x, 1.13.x]
+        go-version: [1.12.x, 1.13.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -20,7 +20,7 @@ jobs:
       with:
         fetch-depth: 1
     - name: Get dependencies
-      run: go mod download || go get -t
+      run: go mod download
     - name: Run unit tests
       run: go test -v ./...
   build-test:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -7,7 +7,7 @@ jobs:
   unit-test:
     strategy:
       matrix:
-        go-version: [1.12.x, 1.13.x]
+        go-version: [1.12.x, 1.13.x, tip]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Go 1.10 and 1.11 are not supported anymore, so removing them from github action tests

Signed-off-by: Patrik Cyvoct <pcyvoct@scaleway.com>