### PR TITLE
chore: remove module downloading step in test jobs

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -19,8 +19,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 1
-    - name: Get dependencies
-      run: go mod download
     - name: Run unit tests
       run: go test -v ./...
   build-arch-test:
@@ -39,8 +37,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 1
-    - name: Get dependencies
-      run: go mod download
     - name: Test to build binary
       run: GOARCH=${{ matrix.arch }} go build ./...
   build-platform-test:
@@ -58,7 +54,5 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 1
-    - name: Get dependencies
-      run: go mod download
     - name: Test to build binary
       run: go build ./...


### PR DESCRIPTION
Downloading Go module explicitly seems useless as `go test` already download needed modules.