### PR TITLE
feat(baremetal): add GetServerOffer and GetOfferFromName

### DIFF
--- a/api/baremetal/v1alpha1/server_utils.go
+++ b/api/baremetal/v1alpha1/server_utils.go
@@ -126,5 +126,5 @@ func (s *API) GetOfferIDFromName(req *GetOfferIDFromOfferNameRequest) (string, e
 		}
 	}
 
-	return "", errors.New("could not find the offer id from name %s", req.OfferName)
+	return "", errors.New("could not find the offer ID from name %s", req.OfferName)
 }

--- a/api/baremetal/v1alpha1/server_utils.go
+++ b/api/baremetal/v1alpha1/server_utils.go
@@ -120,9 +120,9 @@ func (s *API) GetOfferIDFromName(req *GetOfferIDFromOfferNameRequest) (string, e
 		return "", err
 	}
 
-	for _, v := range res.Offers {
-		if req.OfferName == v.Name {
-			return v.ID, nil
+	for _, offer := range res.Offers {
+		if req.OfferName == offer.Name {
+			return offer.ID, nil
 		}
 	}
 

--- a/api/baremetal/v1alpha1/server_utils.go
+++ b/api/baremetal/v1alpha1/server_utils.go
@@ -92,3 +92,40 @@ func (s *API) WaitForServerInstall(req *WaitForServerInstallRequest) (*Server, e
 
 	return server.(*Server), nil
 }
+
+// getServerOfferName returns the offer name of a baremetal server
+func (s *API) GetServerOfferName(server *Server) (string, error) {
+	offer, err := s.GetOffer(&GetOfferRequest{
+		OfferID: server.OfferID,
+		Zone:    server.Zone,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return offer.Name, nil
+}
+
+type GetOfferIDFromOfferNameRequest struct {
+	OfferName string
+	Zone      scw.Zone
+	Timeout   time.Duration
+}
+
+func (s *API) GetOfferIDFromName(req *GetOfferIDFromOfferNameRequest) (string, error) {
+	res, err := s.ListOffers(&ListOffersRequest{
+		Zone: req.Zone,
+	}, scw.WithAllPages())
+
+	if err != nil {
+		return "", err
+	}
+
+	for _, v := range res.Offers {
+		if req.OfferName == v.Name {
+			return v.ID, nil
+		}
+	}
+
+	return "", errors.New("could not find the offer id from name %s", req.OfferName)
+}

--- a/api/baremetal/v1alpha1/server_utils.go
+++ b/api/baremetal/v1alpha1/server_utils.go
@@ -116,7 +116,6 @@ func (s *API) GetOfferIDFromName(req *GetOfferIDFromOfferNameRequest) (string, e
 	res, err := s.ListOffers(&ListOffersRequest{
 		Zone: req.Zone,
 	}, scw.WithAllPages())
-
 	if err != nil {
 		return "", err
 	}

--- a/api/baremetal/v1alpha1/server_utils.go
+++ b/api/baremetal/v1alpha1/server_utils.go
@@ -93,38 +93,38 @@ func (s *API) WaitForServerInstall(req *WaitForServerInstallRequest) (*Server, e
 	return server.(*Server), nil
 }
 
-// GetServerOfferName returns the offer name of a baremetal server
-func (s *API) GetServerOfferName(server *Server) (string, error) {
+// GetServerOffer returns the offer of a baremetal server
+func (s *API) GetServerOffer(server *Server) (*Offer, error) {
 	offer, err := s.GetOffer(&GetOfferRequest{
 		OfferID: server.OfferID,
 		Zone:    server.Zone,
 	})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return offer.Name, nil
+	return offer, nil
 }
 
 type GetOfferIDFromOfferNameRequest struct {
 	OfferName string
 	Zone      scw.Zone
-	Timeout   time.Duration
 }
 
-func (s *API) GetOfferIDFromName(req *GetOfferIDFromOfferNameRequest) (string, error) {
+// GetOfferFromName returns an offer from its commercial name
+func (s *API) GetOfferFromName(req *GetOfferIDFromOfferNameRequest) (*Offer, error) {
 	res, err := s.ListOffers(&ListOffersRequest{
 		Zone: req.Zone,
 	}, scw.WithAllPages())
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	for _, offer := range res.Offers {
 		if req.OfferName == offer.Name {
-			return offer.ID, nil
+			return offer, nil
 		}
 	}
 
-	return "", errors.New("could not find the offer ID from name %s", req.OfferName)
+	return nil, errors.New("could not find the offer ID from name %s", req.OfferName)
 }


### PR DESCRIPTION
This PR adds helper functions that help convert a commercial name such as `GP-BM1-M` with a matching offer id. It also adds the reciprocate function that from an OfferID returns the name.

This is useful in the usage of the CLI where a customer wants to order a bare-metal instance from the commercial name and not from the OfferID (which is a UUID)