### PR TITLE
chore(scw): undeprecate TimeDurationPtr

### DIFF
--- a/scw/convert.go
+++ b/scw/convert.go
@@ -156,7 +156,6 @@ func Float64SlicePtr(src []float64) []*float64 {
 }
 
 // TimeDurationPtr returns a pointer to the Duration value passed in.
-// Deprecated: the use of time.Duration in request is deprecated and only available in lb API
 func TimeDurationPtr(v time.Duration) *time.Duration {
 	return &v
 }

--- a/scw/custom_types_test.go
+++ b/scw/custom_types_test.go
@@ -412,54 +412,59 @@ func TestIPNet_UnmarshalJSON(t *testing.T) {
 func TestDuration_MarshallJSON(t *testing.T) {
 	cases := []struct {
 		name     string
-		duration Duration
+		duration *Duration
 		want     string
 		err      error
 	}{
 		{
 			name:     "small seconds",
-			duration: Duration{Seconds: 3, Nanos: 0},
+			duration: &Duration{Seconds: 3, Nanos: 0},
 			want:     `"3.000000000s"`,
 		},
 		{
 			name:     "small seconds, small nanos",
-			duration: Duration{Seconds: 3, Nanos: 12e7},
+			duration: &Duration{Seconds: 3, Nanos: 12e7},
 			want:     `"3.120000000s"`,
 		},
 		{
 			name:     "small seconds, big nanos",
-			duration: Duration{Seconds: 3, Nanos: 123456789},
+			duration: &Duration{Seconds: 3, Nanos: 123456789},
 			want:     `"3.123456789s"`,
 		},
 		{
 			name:     "big seconds, big nanos",
-			duration: Duration{Seconds: 345679384, Nanos: 123456789},
+			duration: &Duration{Seconds: 345679384, Nanos: 123456789},
 			want:     `"345679384.123456789s"`,
 		},
 		{
 			name:     "negative small seconds",
-			duration: Duration{Seconds: -3, Nanos: 0},
+			duration: &Duration{Seconds: -3, Nanos: 0},
 			want:     `"-3.000000000s"`,
 		},
 		{
 			name:     "negative small seconds, small nanos",
-			duration: Duration{Seconds: -3, Nanos: -12e7},
+			duration: &Duration{Seconds: -3, Nanos: -12e7},
 			want:     `"-3.120000000s"`,
 		},
 		{
 			name:     "negative small seconds, big nanos",
-			duration: Duration{Seconds: -3, Nanos: -123456789},
+			duration: &Duration{Seconds: -3, Nanos: -123456789},
 			want:     `"-3.123456789s"`,
 		},
 		{
 			name:     "negative big seconds, big nanos",
-			duration: Duration{Seconds: -345679384, Nanos: -123456789},
+			duration: &Duration{Seconds: -345679384, Nanos: -123456789},
 			want:     `"-345679384.123456789s"`,
 		},
 		{
 			name:     "negative big seconds, big nanos",
-			duration: Duration{},
+			duration: &Duration{},
 			want:     `"0.000000000s"`,
+		},
+		{
+			name:     "negative big seconds, big nanos",
+			duration: nil,
+			want:     `null`,
 		},
 	}
 

--- a/scw/custom_types_test.go
+++ b/scw/custom_types_test.go
@@ -462,7 +462,7 @@ func TestDuration_MarshallJSON(t *testing.T) {
 			want:     `"0.000000000s"`,
 		},
 		{
-			name:     "negative big seconds, big nanos",
+			name:     "null duration",
 			duration: nil,
 			want:     `null`,
 		},


### PR DESCRIPTION
This method don't need to be deprecated since we rely on `*time.Duration` for `WaitFor` timeouts.