### PR TITLE
fix(core): logger shouldLog checking lower log level

### DIFF
--- a/logger/default_logger.go
+++ b/logger/default_logger.go
@@ -51,7 +51,7 @@ func (g *loggerT) Errorf(format string, args ...interface{}) {
 // ShouldLog reports whether verbosity level l is at least the requested verbose level.
 func ShouldLog(level LogLevel) bool { return logger.ShouldLog(level) }
 func (g *loggerT) ShouldLog(level LogLevel) bool {
-	return level <= g.v
+	return level >= g.v
 }
 
 func isEnabled(envKey string) bool {

--- a/logger/default_logger.go
+++ b/logger/default_logger.go
@@ -22,6 +22,7 @@ type loggerT struct {
 // Not mutex-protected, should be called before any scaleway-sdk-go functions.
 func (g *loggerT) Init(w io.Writer, level LogLevel) {
 	g.m = newLogger(w, level).m
+	g.v = level
 }
 
 // Debugf logs to the DEBUG log. Arguments are handled in the manner of fmt.Printf.


### PR DESCRIPTION
Debug = 0
Warning = 2

With level as Warning, `logger.ShouldLog(Debug)` returned true, it should return false
`Debug <= Warning` is true (wrong)
`Debug >= Warning` is false (good)