### PR TITLE
fix(core): nested logger transport when creating multiple clients

### DIFF
--- a/scw/client.go
+++ b/scw/client.go
@@ -530,5 +530,11 @@ func setRequestLogging(c httpClient) {
 		logger.Warningf("client: cannot use request logger with HTTP client of type %T", c)
 		return
 	}
-	standardHTTPClient.Transport = &requestLoggerTransport{rt: standardHTTPClient.Transport}
+	// Do not wrap transport if it is already a logger
+	// As client is a pointer, changing transport will change given client
+	// If the same httpClient is used in multiple scwClient, it would add multiple logger transports
+	_, isLogger := standardHTTPClient.Transport.(*requestLoggerTransport)
+	if !isLogger {
+		standardHTTPClient.Transport = &requestLoggerTransport{rt: standardHTTPClient.Transport}
+	}
 }

--- a/scw/client_test.go
+++ b/scw/client_test.go
@@ -40,6 +40,27 @@ func TestNewClientWithNoAuth(t *testing.T) {
 	})
 }
 
+func TestNewClientMultipleClients(t *testing.T) {
+	t.Run("Basic", func(t *testing.T) {
+		logger.EnableDebugMode()
+		httpClient := &http.Client{}
+		_, err := NewClient(WithHTTPClient(httpClient))
+		testhelpers.AssertNoError(t, err)
+
+		_, isLogger := httpClient.Transport.(*requestLoggerTransport)
+		testhelpers.Assert(t, isLogger, "transport should be a request logger")
+
+		_, err = NewClient(WithHTTPClient(httpClient))
+		testhelpers.AssertNoError(t, err)
+
+		transport, isLogger := httpClient.Transport.(*requestLoggerTransport)
+		testhelpers.Assert(t, isLogger, "transport should be a request logger")
+		_, isLogger = transport.rt.(*requestLoggerTransport)
+		testhelpers.Assert(t, !isLogger, "nested transport should not be a request logger")
+
+	})
+}
+
 func TestNewClientWithDefaults(t *testing.T) {
 	options := []ClientOption{
 		WithInsecure(),


### PR DESCRIPTION
Current cli because of this:
```
 ± scw --debug instance server get ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b
--------------- Scaleway SDK REQUEST 1 : ---------------
GET /instance/v1/zones/fr-par-1/servers/ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b HTTP/1.1
Host: api.scaleway.com
User-Agent: scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.3; linux; amd64) scaleway-cli/2.0.0+dev
Accept-Encoding: gzip


---------------------------------------------------------
--------------- Scaleway SDK REQUEST 1 : ---------------
GET /instance/v1/zones/fr-par-1/servers/ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b HTTP/1.1
Host: api.scaleway.com
User-Agent: scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19.3; linux; amd64) scaleway-cli/2.0.0+dev
Accept-Encoding: gzip


---------------------------------------------------------

```