### PR TITLE
fix(vpcgw): gateway network terminal status

### DIFF
--- a/api/vpcgw/v1/vpcgw_utils.go
+++ b/api/vpcgw/v1/vpcgw_utils.go
@@ -90,7 +90,6 @@ func (s *API) WaitForGatewayNetwork(req *WaitForGatewayNetworkRequest, opts ...s
 		GatewayNetworkStatusReady:   {},
 		GatewayNetworkStatusUnknown: {},
 		GatewayNetworkStatusDeleted: {},
-		GatewayNetworkStatusCreated: {},
 	}
 
 	gatewayNetwork, err := async.WaitSync(&async.WaitSyncConfig{


### PR DESCRIPTION
When creating a gateway network it will do `created` -> `attaching` -> `ready`

The two status before `ready` are transient status