### PR TITLE
fix(client): validate content-type starting with json

### DIFF
--- a/scw/client.go
+++ b/scw/client.go
@@ -235,13 +235,12 @@ func (c *Client) do(req *ScalewayRequest, res interface{}) (sdkErr error) {
 	if res != nil {
 		contentType := httpResponse.Header.Get("Content-Type")
 
-		switch contentType {
-		case "application/json":
+		if strings.HasPrefix(contentType, "application/json") {
 			err = json.NewDecoder(httpResponse.Body).Decode(&res)
 			if err != nil {
 				return errors.Wrap(err, "could not parse %s response body", contentType)
 			}
-		default:
+		} else {
 			buffer, isBuffer := res.(io.Writer)
 			if !isBuffer {
 				return errors.Wrap(err, "could not handle %s response body with %T result type", contentType, buffer)

--- a/scw/errors.go
+++ b/scw/errors.go
@@ -102,7 +102,8 @@ func hasResponseError(res *http.Response) error {
 	newErr.RawBody = body
 
 	// The error content is not encoded in JSON, only returns HTTP data.
-	if res.Header.Get("Content-Type") != "application/json" {
+	contentType := res.Header.Get("Content-Type")
+	if !strings.HasPrefix(contentType, "application/json") {
 		newErr.Message = res.Status
 		return newErr
 	}


### PR DESCRIPTION
Fix #1679 