### PR TITLE
feat: add UnknownServiceError

### DIFF
--- a/scw/errors.go
+++ b/scw/errors.go
@@ -123,6 +123,13 @@ func hasResponseError(res *http.Response) error {
 		return err
 	}
 
+	if newErr.Type == "" {
+		err = convertNonTypedError(newErr)
+		if err != nil {
+			return err
+		}
+	}
+
 	return newErr
 }
 
@@ -198,6 +205,14 @@ func unmarshalNonStandardError(errorType string, body []byte) error {
 	default:
 		return nil
 	}
+}
+
+func convertNonTypedError(err *ResponseError) error {
+	if err.StatusCode == http.StatusNotImplemented && err.Message == "unknown service" {
+		return &UnknownServiceError{RawBody: err.RawBody}
+	}
+
+	return nil
 }
 
 type InvalidArgumentsErrorDetail struct {
@@ -550,3 +565,16 @@ func (r PreconditionFailedError) Error() string {
 }
 
 func (r PreconditionFailedError) IsScwSdkError() {}
+
+// UnknownServiceError implements the SdkError interface
+type UnknownServiceError struct {
+	RawBody json.RawMessage `json:"-"`
+}
+
+func (e *UnknownServiceError) IsScwSdkError() {}
+func (e *UnknownServiceError) Error() string {
+	return "scaleway-sdk-go: service is unknown in used locality"
+}
+func (e *UnknownServiceError) GetRawBody() json.RawMessage {
+	return e.RawBody
+}

--- a/scw/errors_test.go
+++ b/scw/errors_test.go
@@ -204,3 +204,41 @@ func TestHasResponseErrorWithValidError(t *testing.T) {
 	testhelpers.Assert(t, newErr != nil, "Should have error")
 	testhelpers.Equals(t, testErrorReponse, newErr)
 }
+
+func TestNonTypedError(t *testing.T) {
+	type testCase struct {
+		resStatus     string
+		resStatusCode int
+		resBody       string
+		contentType   string
+		expectedError SdkError
+	}
+
+	run := func(c *testCase) func(t *testing.T) {
+		return func(t *testing.T) {
+			res := &http.Response{
+				Status:     c.resStatus,
+				StatusCode: c.resStatusCode,
+				Body:       ioutil.NopCloser(strings.NewReader(c.resBody)),
+				Header: http.Header{
+					"Content-Type": []string{c.contentType},
+				},
+			}
+
+			// Test that hasResponseError converts the response to the expected SdkError.
+			newErr := hasResponseError(res)
+			testhelpers.Assert(t, newErr != nil, "Should have error")
+			testhelpers.Equals(t, c.expectedError, newErr)
+		}
+	}
+
+	t.Run("unknown service", run(&testCase{
+		resStatus:     "501 Not Implemented",
+		resStatusCode: http.StatusNotImplemented,
+		contentType:   "application/json",
+		resBody:       `{"message": "unknown service"}`,
+		expectedError: &UnknownServiceError{
+			RawBody: []byte(`{"message": "unknown service"}`),
+		},
+	}))
+}


### PR DESCRIPTION
Waiting for a confirmation that the 501 and unknown service error is standard on our api-gateway side.