### PR TITLE
feat(scw): allow usage of http proxy

### DIFF
--- a/scw/client.go
+++ b/scw/client.go
@@ -548,6 +548,7 @@ func newHTTPClient() *http.Client {
 	return &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
 			DialContext:           (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
 			TLSHandshakeTimeout:   5 * time.Second,
 			ResponseHeaderTimeout: 30 * time.Second,


### PR DESCRIPTION
This PR aims to allow usage of an HTTP proxy to communicate with the Scaleway API.

In order to keep this feature simple and standard, I suggest to use the function [ProxyFromEnvironment](https://pkg.go.dev/net/http#ProxyFromEnvironment) from the package `net/http`.