### PR TITLE
Revert "feat(scw): allow usage of http proxy"

### DIFF
--- a/scw/client.go
+++ b/scw/client.go
@@ -548,7 +548,6 @@ func newHTTPClient() *http.Client {
 	return &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
-			Proxy:                 http.ProxyFromEnvironment,
 			DialContext:           (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
 			TLSHandshakeTimeout:   5 * time.Second,
 			ResponseHeaderTimeout: 30 * time.Second,


### PR DESCRIPTION
Reverts scaleway/scaleway-sdk-go#1794

As stated in comment, this change is not needed as the HTTP client can be configured manually:
```go
httpClient := &http.Client{
	Timeout: 30 * time.Second,
	Transport: &http.Transport{
		Proxy:                 http.ProxyFromEnvironment,
		DialContext:           (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
		TLSHandshakeTimeout:   5 * time.Second,
		ResponseHeaderTimeout: 30 * time.Second,
		MaxIdleConnsPerHost:   20,
	},
}
	
client, err := scw.NewClient(scw.WithHTTPClient(httpClient))
if err != nil {
	log.Fatalln(err)
}
```