### PR TITLE
fix(k8s): add ready to terminal statuses for DCP clusters

### DIFF
--- a/api/k8s/v1/k8s_helpers.go
+++ b/api/k8s/v1/k8s_helpers.go
@@ -183,6 +183,7 @@ func (s *API) WaitForClusterPool(req *WaitForClusterRequest, opts ...scw.Request
 
 	terminalStatus := map[ClusterStatus]struct{}{
 		ClusterStatusPoolRequired: {},
+		ClusterStatusReady:        {},
 	}
 
 	cluster, err := async.WaitSync(&async.WaitSyncConfig{


### PR DESCRIPTION
As they finish creation, Dedicated Control-Plane clusters' status is `ready` when in Kapsule clusters it's `pool_required`. This causes the WaitForCluster function to timeout at creation with these types of clusters because the WaitForPool function that it calls only considers `pool_required` to be the sign that the cluster is ready.