### PR TITLE
fix: time ptr query parameter

### DIFF
--- a/internal/parameter/query.go
+++ b/internal/parameter/query.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"reflect"
 	"time"
+
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 
@@ -34,7 +35,7 @@ func AddToQuery(query url.Values, key string, value interface{}) {
 			query.Add(key, fmt.Sprint(elemValue.Index(i).Interface()))
 		}
 	case elemType == reflect.TypeOf(time.Time{}):
-		query.Add(key, value.(time.Time).Format(time.RFC3339))
+		query.Add(key, value.(*time.Time).Format(time.RFC3339))
 	default:
 		query.Add(key, fmt.Sprint(elemValue.Interface()))
 	}


### PR DESCRIPTION
`time.Time` does not exist in query parameters.
It could exist in a List Request but I couldn't find any. 
Used regex: `[^}]List.*Request struct \{(\s|.)*? \*time\.Time(\s|.)*?}`, remove star before time.Time for non-pointer ones.