### PR TITLE
chore(errors): remove toLower conversion for API error messages

### DIFF
--- a/scw/errors.go
+++ b/scw/errors.go
@@ -50,9 +50,6 @@ func (e *ResponseError) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return err
 	}
-
-	tmp.Message = strings.ToLower(tmp.Message)
-
 	*e = ResponseError(tmp)
 	return nil
 }

--- a/scw/errors_test.go
+++ b/scw/errors_test.go
@@ -149,7 +149,7 @@ func TestNonStandardError(t *testing.T) {
 		expectedError: &ResponseError{
 			Status:     "409 Conflict",
 			StatusCode: http.StatusConflict,
-			Message:    "group is in use. you cannot delete it.",
+			Message:    "Group is in use. You cannot delete it.",
 			Type:       "conflict",
 			RawBody:    []byte(`{"message": "Group is in use. You cannot delete it.", "type": "conflict"}`),
 		},


### PR DESCRIPTION
Fix #2155 