### PR TITLE
fix: don't try to read/unmarshal response content when empty

### DIFF
--- a/scw/client.go
+++ b/scw/client.go
@@ -230,7 +230,7 @@ func (c *Client) do(req *ScalewayRequest, res interface{}) (sdkErr error) {
 		return sdkErr
 	}
 
-	if res != nil {
+	if res != nil && httpResponse.ContentLength > 0 {
 		contentType := httpResponse.Header.Get("Content-Type")
 
 		if strings.HasPrefix(contentType, "application/json") {


### PR DESCRIPTION
When an HTTP response body is empty we should not try to read/unmarshal it.