### PR TITLE
fix(scw): read body with unknown content-length

### DIFF
--- a/scw/client.go
+++ b/scw/client.go
@@ -230,7 +230,7 @@ func (c *Client) do(req *ScalewayRequest, res interface{}) (sdkErr error) {
 		return sdkErr
 	}
 
-	if res != nil && httpResponse.ContentLength > 0 {
+	if res != nil && httpResponse.ContentLength != 0 {
 		contentType := httpResponse.Header.Get("Content-Type")
 
 		if strings.HasPrefix(contentType, "application/json") {


### PR DESCRIPTION
From go doc:
```
	// ContentLength records the length of the associated content. The
	// value -1 indicates that the length is unknown. Unless Request.Method
	// is "HEAD", values >= 0 indicate that the given number of bytes may
	// be read from Body.
```

Some requests may have -1 as content-length and still have a body that we must read. A long list response received chunked for example.