### PR TITLE
fix(scw): config.String() panic with an empty profile

### DIFF
--- a/scw/config.go
+++ b/scw/config.go
@@ -145,6 +145,9 @@ func (c *Config) String() string {
 	c2 := c.clone()
 	c2.SecretKey = hideSecretKey(c2.SecretKey)
 	for _, p := range c2.Profiles {
+		if p == nil {
+			continue
+		}
 		p.SecretKey = hideSecretKey(p.SecretKey)
 	}
 

--- a/scw/config_test.go
+++ b/scw/config_test.go
@@ -847,3 +847,32 @@ profiles:
 func TestEmptyConfig(t *testing.T) {
 	testhelpers.Assert(t, (&Config{}).IsEmpty(), "Config must be empty")
 }
+
+func TestEmptyProfile(t *testing.T) {
+	incompleteProfiles := `
+profiles:
+  profile1:
+    access_key: SCW234567890ABCDEFGH
+    secret_key: 6f6e6574-6f72-756c-6c74-68656d616c6c
+    # default_organization_id: 11111111-1111-1111-1111-111111111111
+    # default_project_id: 11111111-1111-1111-1111-111111111111
+    # default_zone: fr-par-1
+    # default_region: fr-pargs
+    # api_url: https://api.scaleway.com
+    # insecure: false
+
+  profile2:
+    # access_key: SCW1234567890ABCDEFG
+    # secret_key: 7363616c-6577-6573-6862-6f7579616161
+`
+
+	config, err := unmarshalConfV2([]byte(incompleteProfiles))
+	testhelpers.AssertNoError(t, err)
+	testhelpers.Equals(t, 2, len(config.Profiles))
+	testhelpers.Equals(t, `profiles:
+  profile1:
+    access_key: SCW234567890ABCDEFGH
+    secret_key: 6f6e6574-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  profile2: null
+`, config.String())
+}


### PR DESCRIPTION
Avoid panic if loading a config with an empty profile, from the CLI
```
➜  scaleway-cli git:(master) ✗ SCW_CLI_CONFIG_PATH="./my_cfg.yml" go run ./cmd/scw/main.go  login -p test
waiting for callback from browser...

                                         @@@@@@@@@@@@@@@.
                                       @@@@@@@@@@@@@@@@@@@@        __          __  _
                                       @@@               @@@@      \ \        / / | |
                                       @@@    @@@@@@@     .@@@      \ \  /\  / /__| | ___ ___  _ __ ___   ___
                                       @@@   @@@@@@@@      @@@       \ \/  \/ / _ \ |/ __/ _ \| '_ ` _ \ / _ \
                                       @@@   @@@           @@@        \  /\  /  __/ | (_| (_) | | | | | |  __/
                                       @@@   @@@     @@@   @@@         \/  \/ \___|_|\___\___/|_| |_| |_|\___|
                                       @@@   @@@     @@@   @@@                                         _  _
                                       @@@           @@@   @@@                                        | |(_)
                                       @@@      .@@@@@@@   @@@             ___   ___ __      __   ___ | | _
                                       @@@      @@@@@@@    @@@            / __| / __|\ \ /\ / /  / __|| || |
                                        @@@.               @@@            \__ \| (__  \ V  V /  | (__ | || |
                                         @@@@@@.         .@@@@            |___/ \___|  \_/\_/    \___||_||_|
                                            @@@@@@@@@@@@@@@@.

------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------------------
An error occurred, we are sorry, please consider opening a ticket on github using: 'scw feedback bug'
Give us as many details as possible so we can reproduce the error and fix it.
---------------------------------------------------------------------------------------
runtime error: invalid memory address or nil pointer dereference
stacktrace from panic:
goroutine 1 [running]:
runtime/debug.Stack()
	/opt/homebrew/Cellar/go/1.24.2/libexec/src/runtime/debug/stack.go:26 +0x64
main.cleanup(0x140000bdd00)
	/Users/gnoale/git/scaleway/scaleway-cli/cmd/scw/main.go:44 +0xa8
panic({0x102a3ce60?, 0x103c78af0?})
	/opt/homebrew/Cellar/go/1.24.2/libexec/src/runtime/panic.go:792 +0x124
github.com/scaleway/scaleway-sdk-go/scw.(*Config).String(0xdf8?)
	/Users/gnoale/go/pkg/mod/github.com/scaleway/scaleway-sdk-go@v1.0.0-beta.33.0.20250422095315-6f998f4655ec/scw/config.go:151 +0x134
github.com/scaleway/scaleway-sdk-go/scw.(*Config).IsEmpty(...)
	/Users/gnoale/go/pkg/mod/github.com/scaleway/scaleway-sdk-go@v1.0.0-beta.33.0.20250422095315-6f998f4655ec/scw/config.go:159
github.com/scaleway/scaleway-cli/v2/internal/namespaces/init.promptProfileOverride({0x102d7ff00, 0x1400036a330}, 0x14000181c20?, {0x140000420d4, 0xc}, {0x16ee8372a, 0x4})
	/Users/gnoale/git/scaleway/scaleway-cli/internal/namespaces/init/prompt.go:250 +0xb4
github.com/scaleway/scaleway-cli/v2/internal/namespaces/init.Command.func1({0x102d7ff00, 0x1400036a330}, {0x1028fdc80?, 0x1400089a980})
	/Users/gnoale/git/scaleway/scaleway-cli/internal/namespaces/init/init.go:148 +0xac
github.com/scaleway/scaleway-cli/v2/internal/namespaces/login.loginCommand.func1({0x102d7ff00, 0x1400036a330}, {0x1028fef80?, 0x140003729c0})
	/Users/gnoale/git/scaleway/scaleway-cli/internal/namespaces/login/login.go:115 +0x568
github.com/scaleway/scaleway-cli/v2/core.run.func1({0x102d7ff00?, 0x1400036a330?}, {0x1028fef80?, 0x140003729c0?})
	/Users/gnoale/git/scaleway/scaleway-cli/core/cobra_utils.go:206 +0x38
github.com/scaleway/scaleway-cli/v2/core.sdkStdTypeInterceptor({0x102d7ff00, 0x1400036a330}, {0x1028fef80?, 0x140003729c0?}, 0x0?)
	/Users/gnoale/git/scaleway/scaleway-cli/core/command_interceptor.go:136 +0x34
github.com/scaleway/scaleway-cli/v2/core.run.CombineCommandInterceptor.func3.1({0x102d7ff00?, 0x1400036a330?}, {0x128ae634bdf2523d?, 0x140000512d8?})
	/Users/gnoale/git/scaleway/scaleway-cli/core/command_interceptor.go:34 +0x38
github.com/scaleway/scaleway-cli/v2/core.sdkStdErrorInterceptor({0x102d7ff00?, 0x1400036a330?}, {0x1028fef80?, 0x140003729c0?}, 0x10?)
	/Users/gnoale/git/scaleway/scaleway-cli/core/command_interceptor.go:49 +0x3c
github.com/scaleway/scaleway-cli/v2/core.run.CombineCommandInterceptor.func3({0x102d7ff00, 0x1400036a330}, {0x1028fef80, 0x140003729c0}, 0x1400062f760)
	/Users/gnoale/git/scaleway/scaleway-cli/core/command_interceptor.go:30 +0xb8
github.com/scaleway/scaleway-cli/v2/core.run({0x102d7ff00, 0x1400036a330}, 0x140008d1808, 0x1400063f8c0, {0x140007fe1e0, 0x0, 0x2})
	/Users/gnoale/git/scaleway/scaleway-cli/core/cobra_utils.go:202 +0x350
github.com/scaleway/scaleway-cli/v2/core.(*cobraBuilder).hydrateCobra.cobraRun.func3(0x140008d1808, {0x140007fe1e0, 0x0, 0x2})
	/Users/gnoale/git/scaleway/scaleway-cli/core/cobra_utils.go:53 +0x238
github.com/spf13/cobra.(*Command).execute(0x140008d1808, {0x140007fe1c0, 0x2, 0x2})
	/Users/gnoale/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1015 +0x828
github.com/spf13/cobra.(*Command).ExecuteC(0x1400003c608)
	/Users/gnoale/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x350
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/gnoale/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
github.com/scaleway/scaleway-cli/v2/core.Bootstrap(0x14000051e50)
	/Users/gnoale/git/scaleway/scaleway-cli/core/bootstrap.go:279 +0xfd0
main.mainNoExit()
	/Users/gnoale/git/scaleway/scaleway-cli/cmd/scw/main.go:86 +0x328
main.main()
	/Users/gnoale/git/scaleway/scaleway-cli/cmd/scw/main.go:67 +0x1c
	``` 