### PR TITLE
fix: Allow for zones as prefix in UUIDs

### DIFF
--- a/validation/is.go
+++ b/validation/is.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	isUUIDRegexp  = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+	isUUIDRegexp  = regexp.MustCompile("^(?:[a-z]{2}-[a-z]{3}-[1-9]/)?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
 	isRegionRegex = regexp.MustCompile("^[a-z]{2}-[a-z]{3}$")
 	isZoneRegex   = regexp.MustCompile("^[a-z]{2}-[a-z]{3}-[1-9]$")
 	isAccessKey   = regexp.MustCompile("^SCW[A-Z0-9]{17}$")

--- a/validation/is_test.go
+++ b/validation/is_test.go
@@ -1,0 +1,28 @@
+package validation
+
+import (
+	"testing"
+)
+
+func Test_IsUUID(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect bool
+	}{
+		{"Valid UUID", "123e4567-e89b-12d3-a456-426614174000", true},
+		{"Invalid UUID - wrong length", "123e4567-e89b-12d3-a456-42661417400", false},
+		{"Invalid UUID - no dashes", "123e4567e89b12d3a456426614174000", false},
+		{"Completely Invalid", "not-a-uuid", false},
+		{"Valid UUID with zone prefix", "fr-par-1/123e4567-e89b-12d3-a456-426614174000", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsUUID(tt.input)
+			if got != tt.expect {
+				t.Errorf("IsUUID(%s) = %v; want %v", tt.input, got, tt.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hello!

I keep getting this warning:
```
╷
│ Warning: Using a datasource for better consistency and reliability is recommended instead of directly using offer names.
│
| ...
│
│ The offer name should be retrieved using a datasource to ensure reliable and consistent configuration.
│
│ Example:
│ data "scaleway_baremetal_offer" "my_offer_monthly" {
│   zone                = "fr-par-2"
│   name                = "EM-B112X-SSD"
│   subscription_period = "monthly"
│ }
│
│ Then, you can reference the datasource's attributes in your resources.
│
│ (and one more similar warning elsewhere)
╵
````

The reason why is since the id used returned by `scaleway_baremetal_offer` is an UUID prefix with the zone, which doesn't match the UUIDs. So this PR ensures that the IsUUID also matches on UUIDs with zone prefix.

If/once this is merged I'll submit a new PR on  updating the SDK in the provider.