### PR TITLE
fix(instance): resolve image label according to boot volume type

### DIFF
--- a/api/instance/v1/server_utils.go
+++ b/api/instance/v1/server_utils.go
@@ -24,11 +24,18 @@ func (s *API) CreateServer(req *CreateServerRequest, opts ...scw.RequestOption) 
 	// If image is not a UUID we try to fetch it from marketplace.
 	if req.Image != nil && !validation.IsUUID(*req.Image) {
 		apiMarketplace := marketplace.NewAPI(s.client)
-		image, err := apiMarketplace.GetLocalImageByLabel(&marketplace.GetLocalImageByLabelRequest{
+
+		getLocalImageByLabelRequest := &marketplace.GetLocalImageByLabelRequest{
 			ImageLabel:     *req.Image,
 			Zone:           req.Zone,
 			CommercialType: req.CommercialType,
-		})
+		}
+
+		if bootVolumeType := getBootVolumeType(req.Volumes); bootVolumeType != nil {
+			getLocalImageByLabelRequest.Type = *bootVolumeType
+		}
+
+		image, err := apiMarketplace.GetLocalImageByLabel(getLocalImageByLabelRequest)
 		if err != nil {
 			return nil, err
 		}
@@ -36,6 +43,36 @@ func (s *API) CreateServer(req *CreateServerRequest, opts ...scw.RequestOption) 
 	}
 
 	return s.createServer(req, opts...)
+}
+
+func getBootVolumeType(volumes map[string]*VolumeServerTemplate) *marketplace.LocalImageType {
+	var bootVolumeType marketplace.LocalImageType
+	foundBootVolume := false
+
+	for _, volume := range volumes {
+		if volume.Boot == nil {
+			continue
+		}
+		if *volume.Boot {
+			foundBootVolume = true
+			switch volume.VolumeType {
+			case VolumeVolumeTypeSbsVolume:
+				bootVolumeType = marketplace.LocalImageTypeInstanceSbs
+			case VolumeVolumeTypeLSSD:
+				bootVolumeType = marketplace.LocalImageTypeInstanceLocal
+			}
+		}
+	}
+
+	if !foundBootVolume && len(volumes) > 0 {
+		switch volumes["0"].VolumeType {
+		case VolumeVolumeTypeSbsVolume:
+			bootVolumeType = marketplace.LocalImageTypeInstanceSbs
+		case VolumeVolumeTypeLSSD:
+			bootVolumeType = marketplace.LocalImageTypeInstanceLocal
+		}
+	}
+	return &bootVolumeType
 }
 
 // UpdateServer updates a server.

--- a/api/instance/v1/server_utils_test.go
+++ b/api/instance/v1/server_utils_test.go
@@ -2,10 +2,14 @@ package instance
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
 
+	block "github.com/scaleway/scaleway-sdk-go/api/block/v1alpha1"
+	"github.com/scaleway/scaleway-sdk-go/api/marketplace/v2"
 	"github.com/scaleway/scaleway-sdk-go/internal/testhelpers"
 	"github.com/scaleway/scaleway-sdk-go/internal/testhelpers/httprecorder"
 	"github.com/scaleway/scaleway-sdk-go/namegenerator"
@@ -165,4 +169,431 @@ func TestAPI_CreateServer(t *testing.T) {
 		ServerID: res.Server.ID,
 	})
 	testhelpers.AssertNoError(t, err)
+}
+
+func TestAPI_CreateServerImageLabelResolution(t *testing.T) {
+	client, r, err := httprecorder.CreateRecordedScwClient("create-server-image-label-resolution")
+	testhelpers.AssertNoError(t, err)
+	defer func() {
+		testhelpers.AssertNoError(t, r.Stop()) // Make sure recorder is stopped once done with it
+	}()
+
+	instanceAPI := NewAPI(client)
+	serverID := ""
+	commercialType := "GP1-XS"
+	imageLabel := "ubuntu_noble"
+	size := 15 * scw.GB
+	zone := scw.ZoneFrPar1
+
+	t.Run("default-root-volume", func(t *testing.T) {
+		// Create a server with default settings
+		res, err := instanceAPI.CreateServer(&CreateServerRequest{
+			Zone:           zone,
+			CommercialType: commercialType,
+			Image:          &imageLabel,
+		})
+		testhelpers.AssertNoError(t, err)
+		serverID = res.Server.ID
+
+		testhelpers.Equals(t, VolumeVolumeTypeLSSD.String(), res.Server.Volumes["0"].VolumeType.String())
+
+		checkImage(t, client, res.Server.Image.ID, imageLabel, commercialType, marketplace.LocalImageTypeInstanceLocal)
+		err = cleanupTestResources(client, serverID)
+		testhelpers.AssertNoError(t, err)
+	})
+
+	t.Run("sbs-root-volume", func(t *testing.T) {
+		volumeType := VolumeVolumeTypeSbsVolume
+
+		// Create server with an SBS root volume
+		res, err := instanceAPI.CreateServer(&CreateServerRequest{
+			Zone:           zone,
+			CommercialType: commercialType,
+			Image:          &imageLabel,
+			Volumes: map[string]*VolumeServerTemplate{
+				"0": {
+					Size:       &size,
+					VolumeType: volumeType,
+				},
+			},
+		})
+		testhelpers.AssertNoError(t, err)
+		serverID = res.Server.ID
+		testhelpers.Equals(t, volumeType.String(), res.Server.Volumes["0"].VolumeType.String())
+		checkImage(t, client, res.Server.Image.ID, imageLabel, commercialType, marketplace.LocalImageTypeInstanceSbs)
+		err = cleanupTestResources(client, serverID)
+		testhelpers.AssertNoError(t, err)
+	})
+
+	t.Run("local-root-volume", func(t *testing.T) {
+		volumeType := VolumeVolumeTypeLSSD
+
+		// Create server with a local root volume
+		res, err := instanceAPI.CreateServer(&CreateServerRequest{
+			Zone:           zone,
+			CommercialType: commercialType,
+			Image:          &imageLabel,
+			Volumes: map[string]*VolumeServerTemplate{
+				"0": {
+					Size:       &size,
+					VolumeType: volumeType,
+				},
+			},
+		})
+		testhelpers.AssertNoError(t, err)
+		serverID = res.Server.ID
+
+		testhelpers.Equals(t, volumeType.String(), res.Server.Volumes["0"].VolumeType.String())
+
+		checkImage(t, client, res.Server.Image.ID, imageLabel, commercialType, marketplace.LocalImageTypeInstanceLocal)
+		err = cleanupTestResources(client, serverID)
+		testhelpers.AssertNoError(t, err)
+	})
+
+	t.Run("sbs-snapshot-volume", func(t *testing.T) {
+		volumeType := VolumeVolumeTypeSbsVolume
+
+		sbsSnapshot := createSBSSnapshot(t, client)
+
+		// Create a server with the sbs snapshot
+		res, err := instanceAPI.CreateServer(&CreateServerRequest{
+			Zone:           zone,
+			CommercialType: commercialType,
+			Image:          &imageLabel,
+			Volumes: map[string]*VolumeServerTemplate{
+				"0": {
+					VolumeType:   volumeType,
+					BaseSnapshot: &sbsSnapshot.ID,
+					Name:         scw.StringPtr("sbs-volume-from-snap"),
+				},
+			},
+		})
+		testhelpers.AssertNoError(t, err)
+		serverID = res.Server.ID
+
+		testhelpers.Equals(t, volumeType.String(), res.Server.Volumes["0"].VolumeType.String())
+
+		checkImage(t, client, res.Server.Image.ID, imageLabel, commercialType, marketplace.LocalImageTypeInstanceSbs)
+		err = cleanupTestResources(client, serverID, sbsSnapshot.ID)
+		testhelpers.AssertNoError(t, err)
+	})
+
+	t.Run("local-snapshot-volume", func(t *testing.T) {
+		volumeType := VolumeVolumeTypeLSSD
+
+		localSnapshot := createLocalSnapshot(t, client)
+
+		// Create a server with the local snapshot
+		res, err := instanceAPI.CreateServer(&CreateServerRequest{
+			Zone:           zone,
+			CommercialType: commercialType,
+			Image:          &imageLabel,
+			Volumes: map[string]*VolumeServerTemplate{
+				"0": {
+					VolumeType:   volumeType,
+					BaseSnapshot: &localSnapshot.ID,
+					Name:         scw.StringPtr("local-volume-from-snap"),
+				},
+			},
+		})
+		testhelpers.AssertNoError(t, err)
+		serverID = res.Server.ID
+
+		testhelpers.Equals(t, volumeType.String(), res.Server.Volumes["0"].VolumeType.String())
+
+		checkImage(t, client, res.Server.Image.ID, imageLabel, commercialType, marketplace.LocalImageTypeInstanceLocal)
+		err = cleanupTestResources(client, serverID, localSnapshot.ID)
+		testhelpers.AssertNoError(t, err)
+	})
+
+	t.Run("sbs-boot-on-custom-index", func(t *testing.T) {
+		blockAPI := block.NewAPI(client)
+		localVolumeType := VolumeVolumeTypeLSSD
+		blockVolumeType := VolumeVolumeTypeSbsVolume
+		boot := true
+
+		// Create sbs volume to boot on
+		sbsVolume, err := blockAPI.CreateVolume(&block.CreateVolumeRequest{
+			Zone:     zone,
+			PerfIops: scw.Uint32Ptr(5000),
+			FromEmpty: &block.CreateVolumeRequestFromEmpty{
+				Size: size,
+			},
+		})
+		testhelpers.AssertNoError(t, err)
+
+		// Create a server that boots on an additional sbs volume
+		res, err := instanceAPI.CreateServer(&CreateServerRequest{
+			Zone:           zone,
+			CommercialType: commercialType,
+			Image:          &imageLabel,
+			Volumes: map[string]*VolumeServerTemplate{
+				"0": {
+					Size:       &size,
+					VolumeType: localVolumeType,
+					Name:       scw.StringPtr("empty-root-volume"),
+				},
+				"1": {
+					VolumeType: blockVolumeType,
+					Boot:       &boot,
+					ID:         &sbsVolume.ID,
+				},
+			},
+		})
+		testhelpers.AssertNoError(t, err)
+		serverID = res.Server.ID
+
+		testhelpers.Equals(t, localVolumeType.String(), res.Server.Volumes["0"].VolumeType.String())
+		testhelpers.Equals(t, blockVolumeType.String(), res.Server.Volumes["1"].VolumeType.String())
+		testhelpers.Equals(t, false, res.Server.Volumes["0"].Boot)
+		testhelpers.Equals(t, true, res.Server.Volumes["1"].Boot)
+
+		checkImage(t, client, res.Server.Image.ID, imageLabel, commercialType, marketplace.LocalImageTypeInstanceSbs)
+		err = cleanupTestResources(client, serverID)
+		testhelpers.AssertNoError(t, err)
+	})
+
+	t.Run("local-boot-on-custom-index", func(t *testing.T) {
+		localVolumeType := VolumeVolumeTypeLSSD
+		blockVolumeType := VolumeVolumeTypeSbsVolume
+		boot := true
+
+		// Create local snapshot for the additional volume to boot on
+		localSnapshot := createLocalSnapshot(t, client)
+
+		// Create block snapshot for the root volume
+		sbsSnapshot := createSBSSnapshot(t, client)
+
+		// Create a server that boots on an additional local volume
+		res, err := instanceAPI.CreateServer(&CreateServerRequest{
+			Zone:           zone,
+			CommercialType: commercialType,
+			Image:          &imageLabel,
+			Volumes: map[string]*VolumeServerTemplate{
+				"0": {
+					VolumeType:   blockVolumeType,
+					BaseSnapshot: &sbsSnapshot.ID,
+					Name:         scw.StringPtr("empty-root-volume"),
+				},
+				"1": {
+					VolumeType:   localVolumeType,
+					Boot:         &boot,
+					BaseSnapshot: &localSnapshot.ID,
+					Name:         scw.StringPtr("boot-on-index-1-local"),
+				},
+			},
+		})
+		testhelpers.AssertNoError(t, err)
+		serverID = res.Server.ID
+
+		testhelpers.Equals(t, blockVolumeType.String(), res.Server.Volumes["0"].VolumeType.String())
+		testhelpers.Equals(t, localVolumeType.String(), res.Server.Volumes["1"].VolumeType.String())
+		testhelpers.Equals(t, false, res.Server.Volumes["0"].Boot)
+		testhelpers.Equals(t, true, res.Server.Volumes["1"].Boot)
+
+		checkImage(t, client, res.Server.Image.ID, imageLabel, commercialType, marketplace.LocalImageTypeInstanceLocal)
+		err = cleanupTestResources(client, serverID, localSnapshot.ID, sbsSnapshot.ID)
+		testhelpers.AssertNoError(t, err)
+	})
+}
+
+func createLocalSnapshot(t *testing.T, client *scw.Client) *Snapshot {
+	t.Helper()
+
+	instanceAPI := NewAPI(client)
+	size := 15 * scw.GB
+	zone, ok := client.GetDefaultZone()
+	if !ok {
+		zone = scw.ZoneFrPar1
+	}
+
+	// Create a server with a local volume to be snapshot
+	tmpServer, err := instanceAPI.CreateServer(&CreateServerRequest{
+		Zone:           zone,
+		CommercialType: "DEV1-S",
+		Image:          scw.StringPtr("ubuntu_focal"),
+		Volumes: map[string]*VolumeServerTemplate{
+			"0": {
+				Size:       &size,
+				VolumeType: VolumeVolumeTypeLSSD,
+			},
+		},
+	})
+	testhelpers.AssertNoError(t, err)
+
+	// Create local snapshot
+	localSnap, err := instanceAPI.CreateSnapshot(&CreateSnapshotRequest{
+		Zone:       zone,
+		VolumeType: SnapshotVolumeTypeLSSD,
+		VolumeID:   &tmpServer.Server.Volumes["0"].ID,
+	})
+	testhelpers.AssertNoError(t, err)
+
+	// Delete temporary server
+	errs := deleteServerAndVolumes(client, tmpServer.Server.ID, zone)
+	if errs != nil {
+		testhelpers.Assert(t, len(errs) == 0, errors.Join(errs...).Error())
+	}
+
+	return localSnap.Snapshot
+}
+
+func createSBSSnapshot(t *testing.T, client *scw.Client) *block.Snapshot {
+	t.Helper()
+
+	blockAPI := block.NewAPI(client)
+	size := 15 * scw.GB
+	zone, ok := client.GetDefaultZone()
+	if !ok {
+		zone = scw.ZoneFrPar1
+	}
+
+	// Create sbs volume to be snapshot
+	tmpVolume, err := blockAPI.CreateVolume(&block.CreateVolumeRequest{
+		Zone:     zone,
+		PerfIops: scw.Uint32Ptr(5000),
+		FromEmpty: &block.CreateVolumeRequestFromEmpty{
+			Size: size,
+		},
+	})
+	testhelpers.AssertNoError(t, err)
+
+	_, err = blockAPI.WaitForVolume(&block.WaitForVolumeRequest{
+		Zone:     zone,
+		VolumeID: tmpVolume.ID,
+	})
+	testhelpers.AssertNoError(t, err)
+
+	// Create sbs snapshot
+	sbsSnap, err := blockAPI.CreateSnapshot(&block.CreateSnapshotRequest{
+		Zone:     zone,
+		VolumeID: tmpVolume.ID,
+	})
+	testhelpers.AssertNoError(t, err)
+
+	// Delete temporary volume
+	sbsSnap, err = blockAPI.WaitForSnapshot(&block.WaitForSnapshotRequest{
+		Zone:       zone,
+		SnapshotID: sbsSnap.ID,
+	})
+	testhelpers.AssertNoError(t, err)
+
+	err = blockAPI.DeleteVolume(&block.DeleteVolumeRequest{
+		Zone:     zone,
+		VolumeID: tmpVolume.ID,
+	})
+	testhelpers.AssertNoError(t, err)
+
+	return sbsSnap
+}
+
+func checkImage(t *testing.T, client *scw.Client, actualImageID string, expectedImageLabel string, commercialType string, expectedLocalImageType marketplace.LocalImageType) {
+	t.Helper()
+
+	// Get the expected marketplace image for comparison
+	marketplaceAPI := marketplace.NewAPI(client)
+	actualImage, err := marketplaceAPI.GetLocalImage(&marketplace.GetLocalImageRequest{
+		LocalImageID: actualImageID,
+	})
+	testhelpers.AssertNoError(t, err)
+	testhelpers.Equals(t, expectedImageLabel, actualImage.Label)
+	testhelpers.Equals(t, expectedLocalImageType, actualImage.Type)
+	testhelpers.Equals(t, scw.ZoneFrPar1, actualImage.Zone)
+	testhelpers.Equals(t, ArchX86_64.String(), actualImage.Arch)
+
+	isCompatible := false
+	for _, compatibleOffer := range actualImage.CompatibleCommercialTypes {
+		if compatibleOffer == commercialType {
+			isCompatible = true
+		}
+	}
+	testhelpers.Assert(t, isCompatible, "actual image is not compatible with requested commercial type")
+}
+
+func deleteServerAndVolumes(client *scw.Client, serverID string, zone scw.Zone) []error {
+	instanceAPI := NewAPI(client)
+	blockAPI := block.NewAPI(client)
+	errs := []error(nil)
+
+	server, err := instanceAPI.GetServer(&GetServerRequest{
+		ServerID: serverID,
+		Zone:     zone,
+	})
+	if err != nil {
+		return append(errs, fmt.Errorf("- failed to get server: %w\n", err))
+	}
+
+	// Delete server first so volumes get detached
+	if serverID != "" {
+		err = instanceAPI.DeleteServer(&DeleteServerRequest{
+			Zone:     scw.ZoneFrPar1,
+			ServerID: serverID,
+		})
+		if err != nil {
+			errs = append(errs, fmt.Errorf("- failed to delete server %s: %w\n", serverID, err))
+		}
+	}
+
+	// Delete volumes
+	for _, volume := range server.Server.Volumes {
+		switch volume.VolumeType {
+		case VolumeServerVolumeTypeLSSD:
+			err = instanceAPI.DeleteVolume(&DeleteVolumeRequest{
+				VolumeID: volume.ID,
+				Zone:     zone,
+			})
+			if err != nil {
+				errs = append(errs, fmt.Errorf("- failed to delete volume %s: %w\n", volume.ID, err))
+			}
+		case VolumeServerVolumeTypeSbsVolume:
+			terminalStatus := block.VolumeStatusAvailable
+			_, err = blockAPI.WaitForVolume(&block.WaitForVolumeRequest{
+				VolumeID:       volume.ID,
+				Zone:           zone,
+				TerminalStatus: &terminalStatus,
+			})
+			if err != nil {
+				errs = append(errs, fmt.Errorf("- failed to wait for volume %s: %w\n", volume.ID, err))
+			}
+
+			err = blockAPI.DeleteVolume(&block.DeleteVolumeRequest{
+				VolumeID: volume.ID,
+				Zone:     zone,
+			})
+			if err != nil {
+				errs = append(errs, fmt.Errorf("- failed to delete volume %s: %w\n", volume.ID, err))
+			}
+		}
+	}
+	return errs
+}
+
+func cleanupTestResources(client *scw.Client, serverID string, snapshotIDs ...string) error {
+	instanceAPI := NewAPI(client)
+	blockAPI := block.NewAPI(client)
+	zone := scw.ZoneFrPar1
+
+	errs := deleteServerAndVolumes(client, serverID, zone)
+
+	// Delete snapshot if needed
+	for _, snapshotID := range snapshotIDs {
+		err := instanceAPI.DeleteSnapshot(&DeleteSnapshotRequest{
+			SnapshotID: snapshotID,
+			Zone:       zone,
+		})
+		if err != nil {
+			errBlock := blockAPI.DeleteSnapshot(&block.DeleteSnapshotRequest{
+				SnapshotID: snapshotID,
+				Zone:       zone,
+			})
+			if errBlock != nil {
+				errs = append(errs, fmt.Errorf("- failed to delete snapshot %s: %w\n", snapshotID, err))
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("cleanup test resources:\n%vThere may be some dangling resources", errors.Join(errs...))
+	}
+	return nil
 }

--- a/api/instance/v1/testdata/create-server-image-label-resolution.yaml
+++ b/api/instance/v1/testdata/create-server-image-label-resolution.yaml
@@ -1,0 +1,3131 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_noble&order_by=type_asc&type=unknown_type&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"c5c72a76-0e9b-437b-a6c9-980d7163c152","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","STARDUST1-S","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB"],"label":"ubuntu_noble","type":"instance_local"},{"id":"95ec2a11-243f-4feb-8efa-155594e2c201","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-48C-192G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-48C-384G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-48C-96G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"label":"ubuntu_noble","type":"instance_sbs"},{"id":"e5758c61-4375-4ce5-b3d5-2f9ffd2b682d","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_noble","type":"instance_sbs"}],"total_count":3}'
+    headers:
+      Content-Length:
+      - "1548"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:32 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 82343e82-53d6-4f01-bb0e-83721849b5d2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"srv-quirky-wing","commercial_type":"GP1-XS","image":"c5c72a76-0e9b-437b-a6c9-980d7163c152","project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+    method: POST
+  response:
+    body: '{"server": {"id": "81887650-5403-4e37-910d-1cfa6bad0b09", "name": "srv-quirky-wing",
+      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-quirky-wing", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "c9aa87c7-29a5-4f6c-a4ec-38013b0c12f8",
+      "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T12:56:49.762531+00:00",
+      "modification_date": "2025-06-25T12:56:49.762531+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "24791535-cc10-48e2-ba99-0232a95dc7f0",
+      "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "81887650-5403-4e37-910d-1cfa6bad0b09", "name": "srv-quirky-wing"},
+      "size": 150000000000, "state": "available", "creation_date": "2025-07-03T23:53:33.021791+00:00",
+      "modification_date": "2025-07-03T23:53:33.021791+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:9b",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:53:33.021791+00:00",
+      "modification_date": "2025-07-03T23:53:33.021791+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2142"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:33 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/81887650-5403-4e37-910d-1cfa6bad0b09
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eccabf8e-26af-40d6-8d00-6208b779b725
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images/c5c72a76-0e9b-437b-a6c9-980d7163c152
+    method: GET
+  response:
+    body: '{"id":"c5c72a76-0e9b-437b-a6c9-980d7163c152","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","STARDUST1-S","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB"],"label":"ubuntu_noble","type":"instance_local"}'
+    headers:
+      Content-Length:
+      - "362"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:33 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2df43f94-34d9-48f9-8aca-4cfb7ae75b29
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/81887650-5403-4e37-910d-1cfa6bad0b09
+    method: GET
+  response:
+    body: '{"server": {"id": "81887650-5403-4e37-910d-1cfa6bad0b09", "name": "srv-quirky-wing",
+      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-quirky-wing", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "c9aa87c7-29a5-4f6c-a4ec-38013b0c12f8",
+      "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T12:56:49.762531+00:00",
+      "modification_date": "2025-06-25T12:56:49.762531+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "24791535-cc10-48e2-ba99-0232a95dc7f0",
+      "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "81887650-5403-4e37-910d-1cfa6bad0b09", "name": "srv-quirky-wing"},
+      "size": 150000000000, "state": "available", "creation_date": "2025-07-03T23:53:33.021791+00:00",
+      "modification_date": "2025-07-03T23:53:33.021791+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:9b",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:53:33.021791+00:00",
+      "modification_date": "2025-07-03T23:53:33.021791+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2142"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:33 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e9d03b16-51a5-419b-be9a-82965008d9bb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/81887650-5403-4e37-910d-1cfa6bad0b09
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:33 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3ca50f0e-63bd-4d6e-b1d8-ef3966ef6b35
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/24791535-cc10-48e2-ba99-0232a95dc7f0
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:33 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 36b3f021-ea27-4410-81e4-19712306a086
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_noble&order_by=type_asc&type=instance_sbs&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"95ec2a11-243f-4feb-8efa-155594e2c201","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-48C-192G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-48C-384G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-48C-96G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"label":"ubuntu_noble","type":"instance_sbs"},{"id":"e5758c61-4375-4ce5-b3d5-2f9ffd2b682d","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_noble","type":"instance_sbs"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1185"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:33 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 21a3eba7-3d2a-48dc-8c4b-c9661c22ac36
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"srv-gifted-rosalind","commercial_type":"GP1-XS","image":"95ec2a11-243f-4feb-8efa-155594e2c201","volumes":{"0":{"size":15000000000,"volume_type":"sbs_volume"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+    method: POST
+  response:
+    body: '{"server": {"id": "f2c898df-0cf8-4b12-802f-2faf7c488ab5", "name": "srv-gifted-rosalind",
+      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-gifted-rosalind", "image": {"id": "95ec2a11-243f-4feb-8efa-155594e2c201",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "e9dae602-1f3d-44c3-b377-a6aed7af0e7e", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2025-06-25T12:56:03.466236+00:00", "modification_date": "2025-06-25T12:56:03.466236+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "9fdfc18e-d0fb-4b98-8da2-586420a5df5f", "zone": "fr-par-1"}}, "tags":
+      [], "state": "stopped", "protected": false, "state_detail": "", "public_ip":
+      null, "public_ips": [], "mac_address": "de:00:00:bb:08:9d", "routed_ip_enabled":
+      true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6":
+      false, "private_ip": null, "creation_date": "2025-07-03T23:53:34.061596+00:00",
+      "modification_date": "2025-07-03T23:53:34.061596+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "1712"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:34 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2c898df-0cf8-4b12-802f-2faf7c488ab5
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e1914587-52b6-4d3c-8d63-01ee70c91d65
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images/95ec2a11-243f-4feb-8efa-155594e2c201
+    method: GET
+  response:
+    body: '{"id":"95ec2a11-243f-4feb-8efa-155594e2c201","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-48C-192G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-48C-384G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-48C-96G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"label":"ubuntu_noble","type":"instance_sbs"}'
+    headers:
+      Content-Length:
+      - "907"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:34 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e9232b77-e8f4-4372-aa04-d0e0c6d43fa7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2c898df-0cf8-4b12-802f-2faf7c488ab5
+    method: GET
+  response:
+    body: '{"server": {"id": "f2c898df-0cf8-4b12-802f-2faf7c488ab5", "name": "srv-gifted-rosalind",
+      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-gifted-rosalind", "image": {"id": "95ec2a11-243f-4feb-8efa-155594e2c201",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "e9dae602-1f3d-44c3-b377-a6aed7af0e7e", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2025-06-25T12:56:03.466236+00:00", "modification_date": "2025-06-25T12:56:03.466236+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "9fdfc18e-d0fb-4b98-8da2-586420a5df5f", "zone": "fr-par-1"}}, "tags":
+      [], "state": "stopped", "protected": false, "state_detail": "", "public_ip":
+      null, "public_ips": [], "mac_address": "de:00:00:bb:08:9d", "routed_ip_enabled":
+      true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6":
+      false, "private_ip": null, "creation_date": "2025-07-03T23:53:34.061596+00:00",
+      "modification_date": "2025-07-03T23:53:34.061596+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "1712"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:34 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 65638727-71ed-4948-b088-f9a2a6815afd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2c898df-0cf8-4b12-802f-2faf7c488ab5
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:35 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5aaf6359-91ba-4629-a272-6fceaf9d61c2
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9fdfc18e-d0fb-4b98-8da2-586420a5df5f
+    method: GET
+  response:
+    body: '{"id":"9fdfc18e-d0fb-4b98-8da2-586420a5df5f","name":"Ubuntu 24.04 Noble
+      Numbat_sbs_volume_0","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:34.184488Z","updated_at":"2025-07-03T23:53:34.184488Z","references":[{"id":"e2e1349e-2378-4568-8e2e-4e406883266d","product_resource_type":"instance_server","product_resource_id":"f2c898df-0cf8-4b12-802f-2faf7c488ab5","created_at":"2025-07-03T23:53:34.184488Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":"e9dae602-1f3d-44c3-b377-a6aed7af0e7e","status":"in_use","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "683"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:35 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 524a2751-904c-4e16-a4c6-e30212aa2893
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9fdfc18e-d0fb-4b98-8da2-586420a5df5f
+    method: GET
+  response:
+    body: '{"id":"9fdfc18e-d0fb-4b98-8da2-586420a5df5f","name":"Ubuntu 24.04 Noble
+      Numbat_sbs_volume_0","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:34.184488Z","updated_at":"2025-07-03T23:53:35.276029Z","references":[],"parent_snapshot_id":"e9dae602-1f3d-44c3-b377-a6aed7af0e7e","status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-07-03T23:53:35.276029Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "481"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:40 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1f30084a-cebb-4e11-9547-f907caf8701c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9fdfc18e-d0fb-4b98-8da2-586420a5df5f
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:40 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ed623825-54c9-45e2-b576-e2f849b9b204
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_noble&order_by=type_asc&type=instance_local&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"c5c72a76-0e9b-437b-a6c9-980d7163c152","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","STARDUST1-S","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB"],"label":"ubuntu_noble","type":"instance_local"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "397"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:40 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 29ca3b6c-25f5-41fd-baf6-49ab5ff470b6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"srv-mystifying-ardinghelli","commercial_type":"GP1-XS","image":"c5c72a76-0e9b-437b-a6c9-980d7163c152","volumes":{"0":{"size":15000000000,"volume_type":"l_ssd"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+    method: POST
+  response:
+    body: '{"server": {"id": "1c73d5ef-57a6-4896-9fb0-4290d8fff8ae", "name": "srv-mystifying-ardinghelli",
+      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-mystifying-ardinghelli", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "c9aa87c7-29a5-4f6c-a4ec-38013b0c12f8",
+      "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T12:56:49.762531+00:00",
+      "modification_date": "2025-06-25T12:56:49.762531+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "62032e23-f4f0-4fe4-9611-ef0e5f1c6052",
+      "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "1c73d5ef-57a6-4896-9fb0-4290d8fff8ae", "name": "srv-mystifying-ardinghelli"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:53:40.686852+00:00",
+      "modification_date": "2025-07-03T23:53:40.686852+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:9f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:53:40.686852+00:00",
+      "modification_date": "2025-07-03T23:53:40.686852+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2174"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:40 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1c73d5ef-57a6-4896-9fb0-4290d8fff8ae
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f4feab6b-1b85-4c6d-9174-b7f5cde67db2
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images/c5c72a76-0e9b-437b-a6c9-980d7163c152
+    method: GET
+  response:
+    body: '{"id":"c5c72a76-0e9b-437b-a6c9-980d7163c152","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","STARDUST1-S","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB"],"label":"ubuntu_noble","type":"instance_local"}'
+    headers:
+      Content-Length:
+      - "362"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:40 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7905b3fb-cdde-4628-90cf-1467c0b77af9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1c73d5ef-57a6-4896-9fb0-4290d8fff8ae
+    method: GET
+  response:
+    body: '{"server": {"id": "1c73d5ef-57a6-4896-9fb0-4290d8fff8ae", "name": "srv-mystifying-ardinghelli",
+      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-mystifying-ardinghelli", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "c9aa87c7-29a5-4f6c-a4ec-38013b0c12f8",
+      "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T12:56:49.762531+00:00",
+      "modification_date": "2025-06-25T12:56:49.762531+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "62032e23-f4f0-4fe4-9611-ef0e5f1c6052",
+      "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "1c73d5ef-57a6-4896-9fb0-4290d8fff8ae", "name": "srv-mystifying-ardinghelli"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:53:40.686852+00:00",
+      "modification_date": "2025-07-03T23:53:40.686852+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:9f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:53:40.686852+00:00",
+      "modification_date": "2025-07-03T23:53:40.686852+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2174"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:41 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bac9870a-0727-45e0-a7e0-1d3059e1aa7d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1c73d5ef-57a6-4896-9fb0-4290d8fff8ae
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:41 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d78745c3-55e5-4147-a17b-32b8f7c8e5d3
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/62032e23-f4f0-4fe4-9611-ef0e5f1c6052
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:41 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - df70b857-948c-4212-878f-a07d4844e6e7
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"name":"vol-jovial-visvesvaraya","perf_iops":5000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","from_empty":{"size":15000000000},"tags":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+    method: POST
+  response:
+    body: '{"id":"cf697d2b-bc1e-4356-a317-74b2d91a3642","name":"vol-jovial-visvesvaraya","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:41.373059Z","updated_at":"2025-07-03T23:53:41.373059Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "406"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:41 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1efde6e5-e2cb-4d8a-8537-c07558545b67
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/cf697d2b-bc1e-4356-a317-74b2d91a3642
+    method: GET
+  response:
+    body: '{"id":"cf697d2b-bc1e-4356-a317-74b2d91a3642","name":"vol-jovial-visvesvaraya","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:41.373059Z","updated_at":"2025-07-03T23:53:41.373059Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "406"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:41 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 67b6dde6-3920-4891-982a-8a80528a0baa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/cf697d2b-bc1e-4356-a317-74b2d91a3642
+    method: GET
+  response:
+    body: '{"id":"cf697d2b-bc1e-4356-a317-74b2d91a3642","name":"vol-jovial-visvesvaraya","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:41.373059Z","updated_at":"2025-07-03T23:53:41.373059Z","references":[],"parent_snapshot_id":null,"status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "407"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:46 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ce9acce2-20e7-457e-9475-5a3d70c30a50
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"volume_id":"cf697d2b-bc1e-4356-a317-74b2d91a3642","name":"snp-confident-elgamal","project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots
+    method: POST
+  response:
+    body: '{"id":"6d3f9df3-60b1-4bd0-8c80-aed482c01140","name":"snp-confident-elgamal","parent_volume":{"id":"cf697d2b-bc1e-4356-a317-74b2d91a3642","name":"vol-jovial-visvesvaraya","type":"sbs_5k","status":"available"},"size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:46.596910Z","updated_at":"2025-07-03T23:53:46.596910Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "443"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:46 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9ec5781d-dd66-4448-bc64-b32468d76412
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/6d3f9df3-60b1-4bd0-8c80-aed482c01140
+    method: GET
+  response:
+    body: '{"id":"6d3f9df3-60b1-4bd0-8c80-aed482c01140","name":"snp-confident-elgamal","parent_volume":{"id":"cf697d2b-bc1e-4356-a317-74b2d91a3642","name":"vol-jovial-visvesvaraya","type":"sbs_5k","status":"available"},"size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:46.596910Z","updated_at":"2025-07-03T23:53:46.596910Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "443"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:46 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 079891de-e3c5-4a1f-a596-7793a31c6f34
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/6d3f9df3-60b1-4bd0-8c80-aed482c01140
+    method: GET
+  response:
+    body: '{"id":"6d3f9df3-60b1-4bd0-8c80-aed482c01140","name":"snp-confident-elgamal","parent_volume":{"id":"cf697d2b-bc1e-4356-a317-74b2d91a3642","name":"vol-jovial-visvesvaraya","type":"sbs_5k","status":"available"},"size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:46.596910Z","updated_at":"2025-07-03T23:53:46.596910Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "444"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 490cee95-7d3d-4e44-a902-736dc4ffadd3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/cf697d2b-bc1e-4356-a317-74b2d91a3642
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3d815054-66d6-4f9c-a0b2-66fba9708338
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_noble&order_by=type_asc&type=instance_sbs&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"95ec2a11-243f-4feb-8efa-155594e2c201","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-48C-192G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-48C-384G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-48C-96G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"label":"ubuntu_noble","type":"instance_sbs"},{"id":"e5758c61-4375-4ce5-b3d5-2f9ffd2b682d","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_noble","type":"instance_sbs"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1185"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8ef5ff6c-fccf-49b3-9e7c-e38a2319056e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"srv-funny-khorana","commercial_type":"GP1-XS","image":"95ec2a11-243f-4feb-8efa-155594e2c201","volumes":{"0":{"name":"sbs-volume-from-snap","volume_type":"sbs_volume","base_snapshot":"6d3f9df3-60b1-4bd0-8c80-aed482c01140"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+    method: POST
+  response:
+    body: '{"server": {"id": "8ccba46a-4b89-4277-a662-e46949a0f0fb", "name": "srv-funny-khorana",
+      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-funny-khorana", "image": {"id": "95ec2a11-243f-4feb-8efa-155594e2c201",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "e9dae602-1f3d-44c3-b377-a6aed7af0e7e", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2025-06-25T12:56:03.466236+00:00", "modification_date": "2025-06-25T12:56:03.466236+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "c110b37a-2547-4d64-b71f-5edcda74197a", "zone": "fr-par-1"}}, "tags":
+      [], "state": "stopped", "protected": false, "state_detail": "", "public_ip":
+      null, "public_ips": [], "mac_address": "de:00:00:bb:08:a7", "routed_ip_enabled":
+      true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6":
+      false, "private_ip": null, "creation_date": "2025-07-03T23:53:52.404140+00:00",
+      "modification_date": "2025-07-03T23:53:52.404140+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "1708"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:52 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ccba46a-4b89-4277-a662-e46949a0f0fb
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d137ec9b-4a3f-4650-a7f1-044b1df96d5c
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images/95ec2a11-243f-4feb-8efa-155594e2c201
+    method: GET
+  response:
+    body: '{"id":"95ec2a11-243f-4feb-8efa-155594e2c201","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-48C-192G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-48C-384G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-48C-96G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"label":"ubuntu_noble","type":"instance_sbs"}'
+    headers:
+      Content-Length:
+      - "907"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ce378aa6-da15-4899-b3c2-bab56d350bfc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ccba46a-4b89-4277-a662-e46949a0f0fb
+    method: GET
+  response:
+    body: '{"server": {"id": "8ccba46a-4b89-4277-a662-e46949a0f0fb", "name": "srv-funny-khorana",
+      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-funny-khorana", "image": {"id": "95ec2a11-243f-4feb-8efa-155594e2c201",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "e9dae602-1f3d-44c3-b377-a6aed7af0e7e", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2025-06-25T12:56:03.466236+00:00", "modification_date": "2025-06-25T12:56:03.466236+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "c110b37a-2547-4d64-b71f-5edcda74197a", "zone": "fr-par-1"}}, "tags":
+      [], "state": "stopped", "protected": false, "state_detail": "", "public_ip":
+      null, "public_ips": [], "mac_address": "de:00:00:bb:08:a7", "routed_ip_enabled":
+      true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6":
+      false, "private_ip": null, "creation_date": "2025-07-03T23:53:52.404140+00:00",
+      "modification_date": "2025-07-03T23:53:52.404140+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "1708"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7a0473d4-d3fc-49d0-8a43-45eeb3be08e9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ccba46a-4b89-4277-a662-e46949a0f0fb
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 49590171-e8bd-4d15-bb66-83a66fd85db3
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/c110b37a-2547-4d64-b71f-5edcda74197a
+    method: GET
+  response:
+    body: '{"id":"c110b37a-2547-4d64-b71f-5edcda74197a","name":"sbs-volume-from-snap","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:52.523668Z","updated_at":"2025-07-03T23:53:52.523668Z","references":[{"id":"635ff0d0-7021-4a31-a5c0-c7abba738996","product_resource_type":"instance_server","product_resource_id":"8ccba46a-4b89-4277-a662-e46949a0f0fb","created_at":"2025-07-03T23:53:52.523668Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":"6d3f9df3-60b1-4bd0-8c80-aed482c01140","status":"in_use","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "665"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 49649718-8880-46f4-8853-439551c75299
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/c110b37a-2547-4d64-b71f-5edcda74197a
+    method: GET
+  response:
+    body: '{"id":"c110b37a-2547-4d64-b71f-5edcda74197a","name":"sbs-volume-from-snap","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:52.523668Z","updated_at":"2025-07-03T23:53:53.348660Z","references":[],"parent_snapshot_id":"6d3f9df3-60b1-4bd0-8c80-aed482c01140","status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-07-03T23:53:53.348660Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "463"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 437d84d2-01c8-4ce7-b04b-c1d1ee0819e3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/c110b37a-2547-4d64-b71f-5edcda74197a
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 57e3e254-266f-4c63-92d6-861f70bc9420
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/6d3f9df3-60b1-4bd0-8c80-aed482c01140
+    method: DELETE
+  response:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_snapshot",
+      "resource_id": "6d3f9df3-60b1-4bd0-8c80-aed482c01140"}'
+    headers:
+      Content-Length:
+      - "145"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bf9eff8f-014a-4342-8cf4-d97bc22d35ef
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/6d3f9df3-60b1-4bd0-8c80-aed482c01140
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 01e80663-efe2-49ae-9e5a-d82fed48a841
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"4a4d2994-e7e0-4b29-a760-36235e6ba258","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","STARDUST1-S","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB"],"label":"ubuntu_focal","type":"instance_local"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "397"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c13480b8-444e-4199-ad03-b8bd66a26cae
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"srv-festive-maxwell","commercial_type":"DEV1-S","image":"4a4d2994-e7e0-4b29-a760-36235e6ba258","volumes":{"0":{"size":15000000000,"volume_type":"l_ssd"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+    method: POST
+  response:
+    body: '{"server": {"id": "04a07a9e-ed86-4745-9fd9-9c71905047bf", "name": "srv-festive-maxwell",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-festive-maxwell", "image": {"id": "4a4d2994-e7e0-4b29-a760-36235e6ba258",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "37000787-865a-4306-8ac4-5a0b2e2fcbbe",
+      "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:47:39.547126+00:00",
+      "modification_date": "2025-06-25T15:47:39.547126+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "800f51c5-d519-485e-a114-9aa7a9c8d20e",
+      "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "04a07a9e-ed86-4745-9fd9-9c71905047bf", "name": "srv-festive-maxwell"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:53:58.968318+00:00",
+      "modification_date": "2025-07-03T23:53:58.968318+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:a9",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:53:58.968318+00:00",
+      "modification_date": "2025-07-03T23:53:58.968318+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2150"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:59 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04a07a9e-ed86-4745-9fd9-9c71905047bf
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 076cdbc4-ad48-414f-b462-4289b91dfac5
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"name":"snp-reverent-blackburn","volume_id":"800f51c5-d519-485e-a114-9aa7a9c8d20e","project":"19a4819b-24bf-4d44-969f-935ef0061b71","volume_type":"l_ssd"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
+    method: POST
+  response:
+    body: '{"snapshot": {"id": "25957e58-ceaa-4ec9-9167-73f06e947699", "name": "snp-reverent-blackburn",
+      "volume_type": "l_ssd", "creation_date": "2025-07-03T23:53:59.254516+00:00",
+      "modification_date": "2025-07-03T23:53:59.254516+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "size": 15000000000, "state":
+      "available", "base_volume": {"id": "800f51c5-d519-485e-a114-9aa7a9c8d20e", "name":
+      "Ubuntu 20.04 Focal Fossa"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}, "task": {"id": "9fd878a6-5d5c-448a-ae1b-3519dd8a9b62", "description":
+      "volume_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
+      "snapshots/25957e58-ceaa-4ec9-9167-73f06e947699", "started_at": "2025-07-03T23:53:59.487341+00:00",
+      "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "843"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 99aa2a6c-7c11-46ac-ad3c-b49144b2469f
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04a07a9e-ed86-4745-9fd9-9c71905047bf
+    method: GET
+  response:
+    body: '{"server": {"id": "04a07a9e-ed86-4745-9fd9-9c71905047bf", "name": "srv-festive-maxwell",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-festive-maxwell", "image": {"id": "4a4d2994-e7e0-4b29-a760-36235e6ba258",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "37000787-865a-4306-8ac4-5a0b2e2fcbbe",
+      "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:47:39.547126+00:00",
+      "modification_date": "2025-06-25T15:47:39.547126+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "800f51c5-d519-485e-a114-9aa7a9c8d20e",
+      "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "04a07a9e-ed86-4745-9fd9-9c71905047bf", "name": "srv-festive-maxwell"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:53:58.968318+00:00",
+      "modification_date": "2025-07-03T23:53:58.968318+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:a9",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:53:58.968318+00:00",
+      "modification_date": "2025-07-03T23:53:58.968318+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2150"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 85cf846c-0ff1-42f7-843f-8a1aac5aa7d5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04a07a9e-ed86-4745-9fd9-9c71905047bf
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e9449c4e-b9f0-4e71-a1d2-42617fd79a9a
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/800f51c5-d519-485e-a114-9aa7a9c8d20e
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 57b97d97-1ad1-40fc-9268-c9bf6ceed1f5
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_noble&order_by=type_asc&type=instance_local&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"c5c72a76-0e9b-437b-a6c9-980d7163c152","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","STARDUST1-S","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB"],"label":"ubuntu_noble","type":"instance_local"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "397"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:53:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 952a85ff-d27d-4d70-afec-32fb00f59654
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"srv-affectionate-elgamal","commercial_type":"GP1-XS","image":"c5c72a76-0e9b-437b-a6c9-980d7163c152","volumes":{"0":{"name":"local-volume-from-snap","volume_type":"l_ssd","base_snapshot":"25957e58-ceaa-4ec9-9167-73f06e947699"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+    method: POST
+  response:
+    body: '{"server": {"id": "ed4587e3-a873-4a27-92eb-39dbd03e8070", "name": "srv-affectionate-elgamal",
+      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-affectionate-elgamal", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "c9aa87c7-29a5-4f6c-a4ec-38013b0c12f8",
+      "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T12:56:49.762531+00:00",
+      "modification_date": "2025-06-25T12:56:49.762531+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "107b9908-8b0a-440e-a401-7dfea41eac4d",
+      "name": "local-volume-from-snap", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "ed4587e3-a873-4a27-92eb-39dbd03e8070", "name": "srv-affectionate-elgamal"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:54:00.329514+00:00",
+      "modification_date": "2025-07-03T23:54:00.329514+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:ad",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:54:00.329514+00:00",
+      "modification_date": "2025-07-03T23:54:00.329514+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2165"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:00 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ed4587e3-a873-4a27-92eb-39dbd03e8070
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7273eddd-0377-44e9-8382-1ea3de0850c0
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images/c5c72a76-0e9b-437b-a6c9-980d7163c152
+    method: GET
+  response:
+    body: '{"id":"c5c72a76-0e9b-437b-a6c9-980d7163c152","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","STARDUST1-S","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB"],"label":"ubuntu_noble","type":"instance_local"}'
+    headers:
+      Content-Length:
+      - "362"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:00 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5c082187-cbbd-4b2b-b016-b60ac0b7a31b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ed4587e3-a873-4a27-92eb-39dbd03e8070
+    method: GET
+  response:
+    body: '{"server": {"id": "ed4587e3-a873-4a27-92eb-39dbd03e8070", "name": "srv-affectionate-elgamal",
+      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-affectionate-elgamal", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "c9aa87c7-29a5-4f6c-a4ec-38013b0c12f8",
+      "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T12:56:49.762531+00:00",
+      "modification_date": "2025-06-25T12:56:49.762531+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "107b9908-8b0a-440e-a401-7dfea41eac4d",
+      "name": "local-volume-from-snap", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "ed4587e3-a873-4a27-92eb-39dbd03e8070", "name": "srv-affectionate-elgamal"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:54:00.329514+00:00",
+      "modification_date": "2025-07-03T23:54:00.329514+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:ad",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:54:00.329514+00:00",
+      "modification_date": "2025-07-03T23:54:00.329514+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2165"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:01 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e1c0ab22-7757-43ec-94b8-cfd37f3e4fea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ed4587e3-a873-4a27-92eb-39dbd03e8070
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:01 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1bcc94e7-f457-49be-9941-f0fbea603314
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/107b9908-8b0a-440e-a401-7dfea41eac4d
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:01 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 94c27c09-95bd-43bf-adcb-055bea874252
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/25957e58-ceaa-4ec9-9167-73f06e947699
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:01 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d6e061ef-2826-44b4-bef1-04dc73ae4802
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"name":"vol-vibrant-poitras","perf_iops":5000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","from_empty":{"size":15000000000},"tags":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+    method: POST
+  response:
+    body: '{"id":"925759ec-00b4-45a8-88a8-bb3503c70e87","name":"vol-vibrant-poitras","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:01.477518Z","updated_at":"2025-07-03T23:54:01.477518Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "402"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:01 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 012bb6a4-e5e7-4c1b-ad61-0f53bb78d7ef
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_noble&order_by=type_asc&type=instance_sbs&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"95ec2a11-243f-4feb-8efa-155594e2c201","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-48C-192G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-48C-384G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-48C-96G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"label":"ubuntu_noble","type":"instance_sbs"},{"id":"e5758c61-4375-4ce5-b3d5-2f9ffd2b682d","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_noble","type":"instance_sbs"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1185"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:01 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 74d773fd-a3cd-4fec-84bf-fc0026ce29d2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"srv-sleepy-aryabhata","commercial_type":"GP1-XS","image":"95ec2a11-243f-4feb-8efa-155594e2c201","volumes":{"0":{"name":"empty-root-volume","size":15000000000,"volume_type":"l_ssd"},"1":{"id":"925759ec-00b4-45a8-88a8-bb3503c70e87","boot":true,"volume_type":"sbs_volume"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+    method: POST
+  response:
+    body: '{"server": {"id": "40b03479-f3a5-4716-a4e9-b30e9fbec971", "name": "srv-sleepy-aryabhata",
+      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-sleepy-aryabhata", "image": {"id": "95ec2a11-243f-4feb-8efa-155594e2c201",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "e9dae602-1f3d-44c3-b377-a6aed7af0e7e", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2025-06-25T12:56:03.466236+00:00", "modification_date": "2025-06-25T12:56:03.466236+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "6c4e901f-d3e2-4129-bf2c-657fc83ed5ec",
+      "name": "empty-root-volume", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "40b03479-f3a5-4716-a4e9-b30e9fbec971", "name": "srv-sleepy-aryabhata"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:54:01.824529+00:00",
+      "modification_date": "2025-07-03T23:54:01.824529+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": true, "volume_type": "sbs_volume", "id": "925759ec-00b4-45a8-88a8-bb3503c70e87",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:af",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:54:01.824529+00:00",
+      "modification_date": "2025-07-03T23:54:01.824529+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2236"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:02 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/40b03479-f3a5-4716-a4e9-b30e9fbec971
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1b469dd7-f605-4501-b857-26cd4168f38f
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images/95ec2a11-243f-4feb-8efa-155594e2c201
+    method: GET
+  response:
+    body: '{"id":"95ec2a11-243f-4feb-8efa-155594e2c201","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-48C-192G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-48C-384G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-48C-96G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"label":"ubuntu_noble","type":"instance_sbs"}'
+    headers:
+      Content-Length:
+      - "907"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:02 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9f486c24-a30f-4b0b-85c2-293ed58f9189
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/40b03479-f3a5-4716-a4e9-b30e9fbec971
+    method: GET
+  response:
+    body: '{"server": {"id": "40b03479-f3a5-4716-a4e9-b30e9fbec971", "name": "srv-sleepy-aryabhata",
+      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-sleepy-aryabhata", "image": {"id": "95ec2a11-243f-4feb-8efa-155594e2c201",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "e9dae602-1f3d-44c3-b377-a6aed7af0e7e", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2025-06-25T12:56:03.466236+00:00", "modification_date": "2025-06-25T12:56:03.466236+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "6c4e901f-d3e2-4129-bf2c-657fc83ed5ec",
+      "name": "empty-root-volume", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "40b03479-f3a5-4716-a4e9-b30e9fbec971", "name": "srv-sleepy-aryabhata"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:54:01.824529+00:00",
+      "modification_date": "2025-07-03T23:54:01.824529+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": true, "volume_type": "sbs_volume", "id": "925759ec-00b4-45a8-88a8-bb3503c70e87",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:af",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:54:01.824529+00:00",
+      "modification_date": "2025-07-03T23:54:01.824529+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2236"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:02 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 59e41dd5-cc6e-422b-a610-a71e6316ea57
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/40b03479-f3a5-4716-a4e9-b30e9fbec971
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7aa2d9e2-1bf2-43aa-a9fe-6ab3c44d013f
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6c4e901f-d3e2-4129-bf2c-657fc83ed5ec
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3bbae38d-534f-4365-b034-b34a7b72e7f1
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/925759ec-00b4-45a8-88a8-bb3503c70e87
+    method: GET
+  response:
+    body: '{"id":"925759ec-00b4-45a8-88a8-bb3503c70e87","name":"vol-vibrant-poitras","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:01.477518Z","updated_at":"2025-07-03T23:54:03.277848Z","references":[],"parent_snapshot_id":null,"status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-07-03T23:54:03.277848Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "428"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d8484cee-5fdc-48cb-82ee-70026af22c1a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/925759ec-00b4-45a8-88a8-bb3503c70e87
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 498e40f7-fb17-41ca-8877-95c1ed4631e0
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"4a4d2994-e7e0-4b29-a760-36235e6ba258","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","STARDUST1-S","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB"],"label":"ubuntu_focal","type":"instance_local"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "397"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aac18afb-9888-453d-af34-42be8075ebc9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"srv-vigilant-cartwright","commercial_type":"DEV1-S","image":"4a4d2994-e7e0-4b29-a760-36235e6ba258","volumes":{"0":{"size":15000000000,"volume_type":"l_ssd"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+    method: POST
+  response:
+    body: '{"server": {"id": "d20190a3-a38f-4423-b1c0-c4a16fb89210", "name": "srv-vigilant-cartwright",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-vigilant-cartwright", "image": {"id": "4a4d2994-e7e0-4b29-a760-36235e6ba258",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "37000787-865a-4306-8ac4-5a0b2e2fcbbe",
+      "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:47:39.547126+00:00",
+      "modification_date": "2025-06-25T15:47:39.547126+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "f1b7a5e2-6866-4b44-b32b-31f04f396ac0",
+      "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "d20190a3-a38f-4423-b1c0-c4a16fb89210", "name": "srv-vigilant-cartwright"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:54:03.672754+00:00",
+      "modification_date": "2025-07-03T23:54:03.672754+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:b1",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:54:03.672754+00:00",
+      "modification_date": "2025-07-03T23:54:03.672754+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2162"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:03 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d20190a3-a38f-4423-b1c0-c4a16fb89210
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c5bf1369-944b-48eb-a9c8-2aeba6c71f16
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"name":"snp-upbeat-northcutt","volume_id":"f1b7a5e2-6866-4b44-b32b-31f04f396ac0","project":"19a4819b-24bf-4d44-969f-935ef0061b71","volume_type":"l_ssd"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
+    method: POST
+  response:
+    body: '{"snapshot": {"id": "d0672d86-a469-4e2e-82dd-7923d7e22813", "name": "snp-upbeat-northcutt",
+      "volume_type": "l_ssd", "creation_date": "2025-07-03T23:54:03.997474+00:00",
+      "modification_date": "2025-07-03T23:54:03.997474+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "size": 15000000000, "state":
+      "available", "base_volume": {"id": "f1b7a5e2-6866-4b44-b32b-31f04f396ac0", "name":
+      "Ubuntu 20.04 Focal Fossa"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}, "task": {"id": "dd9bde21-4415-425e-b69a-10f03d6eae7a", "description":
+      "volume_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
+      "snapshots/d0672d86-a469-4e2e-82dd-7923d7e22813", "started_at": "2025-07-03T23:54:04.201701+00:00",
+      "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "841"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:04 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b8905fe3-78db-48ff-84a1-66594674eabd
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d20190a3-a38f-4423-b1c0-c4a16fb89210
+    method: GET
+  response:
+    body: '{"server": {"id": "d20190a3-a38f-4423-b1c0-c4a16fb89210", "name": "srv-vigilant-cartwright",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-vigilant-cartwright", "image": {"id": "4a4d2994-e7e0-4b29-a760-36235e6ba258",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "37000787-865a-4306-8ac4-5a0b2e2fcbbe",
+      "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:47:39.547126+00:00",
+      "modification_date": "2025-06-25T15:47:39.547126+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "f1b7a5e2-6866-4b44-b32b-31f04f396ac0",
+      "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "d20190a3-a38f-4423-b1c0-c4a16fb89210", "name": "srv-vigilant-cartwright"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:54:03.672754+00:00",
+      "modification_date": "2025-07-03T23:54:03.672754+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:b1",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:54:03.672754+00:00",
+      "modification_date": "2025-07-03T23:54:03.672754+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2162"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:04 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b2aff180-1b41-47a2-89cd-414d69e26067
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d20190a3-a38f-4423-b1c0-c4a16fb89210
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:04 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d65560cf-995d-4e12-85ec-519d7a3c1359
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f1b7a5e2-6866-4b44-b32b-31f04f396ac0
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:04 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1d82831a-1a20-4f1d-8e1d-f934423e5538
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"name":"vol-loving-mclean","perf_iops":5000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","from_empty":{"size":15000000000},"tags":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+    method: POST
+  response:
+    body: '{"id":"9f4ac333-112b-440c-a257-658829ef7754","name":"vol-loving-mclean","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:04.700794Z","updated_at":"2025-07-03T23:54:04.700794Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "400"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:04 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 66764e6a-1c41-4a76-a94c-0bf7da9500ab
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9f4ac333-112b-440c-a257-658829ef7754
+    method: GET
+  response:
+    body: '{"id":"9f4ac333-112b-440c-a257-658829ef7754","name":"vol-loving-mclean","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:04.700794Z","updated_at":"2025-07-03T23:54:04.700794Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "400"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:04 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5f2eb5a3-3cdc-4c0a-a56d-214423840f0a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9f4ac333-112b-440c-a257-658829ef7754
+    method: GET
+  response:
+    body: '{"id":"9f4ac333-112b-440c-a257-658829ef7754","name":"vol-loving-mclean","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:04.700794Z","updated_at":"2025-07-03T23:54:04.700794Z","references":[],"parent_snapshot_id":null,"status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "401"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:09 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 059ece41-f257-4825-82a5-a90a14516209
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"volume_id":"9f4ac333-112b-440c-a257-658829ef7754","name":"snp-elegant-bose","project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots
+    method: POST
+  response:
+    body: '{"id":"be0aba55-1a40-406f-8010-cf483a8f6018","name":"snp-elegant-bose","parent_volume":{"id":"9f4ac333-112b-440c-a257-658829ef7754","name":"vol-loving-mclean","type":"sbs_5k","status":"available"},"size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:09.916299Z","updated_at":"2025-07-03T23:54:09.916299Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "432"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:10 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8a49ae22-ff28-451a-92b1-6dd30ff28947
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/be0aba55-1a40-406f-8010-cf483a8f6018
+    method: GET
+  response:
+    body: '{"id":"be0aba55-1a40-406f-8010-cf483a8f6018","name":"snp-elegant-bose","parent_volume":{"id":"9f4ac333-112b-440c-a257-658829ef7754","name":"vol-loving-mclean","type":"sbs_5k","status":"available"},"size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:09.916299Z","updated_at":"2025-07-03T23:54:09.916299Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "432"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:10 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 26225f20-9af8-4a45-b24e-236e989f4c3b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/be0aba55-1a40-406f-8010-cf483a8f6018
+    method: GET
+  response:
+    body: '{"id":"be0aba55-1a40-406f-8010-cf483a8f6018","name":"snp-elegant-bose","parent_volume":{"id":"9f4ac333-112b-440c-a257-658829ef7754","name":"vol-loving-mclean","type":"sbs_5k","status":"available"},"size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:09.916299Z","updated_at":"2025-07-03T23:54:09.916299Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "433"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:15 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b0f0070a-307e-4925-8c8d-27aa7eab9d4a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9f4ac333-112b-440c-a257-658829ef7754
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:15 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 04094111-a444-453e-815f-8b441cf793b8
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_noble&order_by=type_asc&type=instance_local&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"c5c72a76-0e9b-437b-a6c9-980d7163c152","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","STARDUST1-S","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB"],"label":"ubuntu_noble","type":"instance_local"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "397"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:15 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1ea44361-d9e7-4d22-bd43-83f0906b362b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"srv-priceless-lamarr","commercial_type":"GP1-XS","image":"c5c72a76-0e9b-437b-a6c9-980d7163c152","volumes":{"0":{"name":"empty-root-volume","volume_type":"sbs_volume","base_snapshot":"be0aba55-1a40-406f-8010-cf483a8f6018"},"1":{"boot":true,"name":"boot-on-index-1-local","volume_type":"l_ssd","base_snapshot":"d0672d86-a469-4e2e-82dd-7923d7e22813"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+    method: POST
+  response:
+    body: '{"server": {"id": "e3738cc7-cc88-458b-a3c3-bdb6577c1577", "name": "srv-priceless-lamarr",
+      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-priceless-lamarr", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "c9aa87c7-29a5-4f6c-a4ec-38013b0c12f8",
+      "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T12:56:49.762531+00:00",
+      "modification_date": "2025-06-25T12:56:49.762531+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "3725e6f2-c7b0-44b0-8306-c76e2fd1e9ca",
+      "zone": "fr-par-1"}, "1": {"boot": true, "id": "c26f0619-02d2-4e47-9125-d2ea307476de",
+      "name": "boot-on-index-1-local", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "e3738cc7-cc88-458b-a3c3-bdb6577c1577", "name": "srv-priceless-lamarr"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:54:15.766179+00:00",
+      "modification_date": "2025-07-03T23:54:15.766179+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:b5",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:54:15.766179+00:00",
+      "modification_date": "2025-07-03T23:54:15.766179+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2268"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:16 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3738cc7-cc88-458b-a3c3-bdb6577c1577
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e8520533-b9ef-43e5-b242-e772fd954f2e
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images/c5c72a76-0e9b-437b-a6c9-980d7163c152
+    method: GET
+  response:
+    body: '{"id":"c5c72a76-0e9b-437b-a6c9-980d7163c152","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","STARDUST1-S","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB"],"label":"ubuntu_noble","type":"instance_local"}'
+    headers:
+      Content-Length:
+      - "362"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 63e46f8c-8e69-41d8-a614-6086b6adb2f6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3738cc7-cc88-458b-a3c3-bdb6577c1577
+    method: GET
+  response:
+    body: '{"server": {"id": "e3738cc7-cc88-458b-a3c3-bdb6577c1577", "name": "srv-priceless-lamarr",
+      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-priceless-lamarr", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "c9aa87c7-29a5-4f6c-a4ec-38013b0c12f8",
+      "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T12:56:49.762531+00:00",
+      "modification_date": "2025-06-25T12:56:49.762531+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "3725e6f2-c7b0-44b0-8306-c76e2fd1e9ca",
+      "zone": "fr-par-1"}, "1": {"boot": true, "id": "c26f0619-02d2-4e47-9125-d2ea307476de",
+      "name": "boot-on-index-1-local", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "e3738cc7-cc88-458b-a3c3-bdb6577c1577", "name": "srv-priceless-lamarr"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:54:15.766179+00:00",
+      "modification_date": "2025-07-03T23:54:15.766179+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:b5",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:54:15.766179+00:00",
+      "modification_date": "2025-07-03T23:54:15.766179+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2268"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f71059ee-18a3-488f-9519-5691f146b2d2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3738cc7-cc88-458b-a3c3-bdb6577c1577
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 049ac81c-7117-46f4-886b-87786c23badd
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/3725e6f2-c7b0-44b0-8306-c76e2fd1e9ca
+    method: GET
+  response:
+    body: '{"id":"3725e6f2-c7b0-44b0-8306-c76e2fd1e9ca","name":"empty-root-volume","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:15.879185Z","updated_at":"2025-07-03T23:54:15.879185Z","references":[{"id":"8b226362-58c5-407c-ac98-25d314b6bef9","product_resource_type":"instance_server","product_resource_id":"e3738cc7-cc88-458b-a3c3-bdb6577c1577","created_at":"2025-07-03T23:54:15.879185Z","type":"exclusive","status":"detaching"}],"parent_snapshot_id":"be0aba55-1a40-406f-8010-cf483a8f6018","status":"in_use","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "663"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bcf9af64-abe0-42ec-86f6-7207897287c6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/3725e6f2-c7b0-44b0-8306-c76e2fd1e9ca
+    method: GET
+  response:
+    body: '{"id":"3725e6f2-c7b0-44b0-8306-c76e2fd1e9ca","name":"empty-root-volume","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:15.879185Z","updated_at":"2025-07-03T23:54:16.968317Z","references":[],"parent_snapshot_id":"be0aba55-1a40-406f-8010-cf483a8f6018","status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-07-03T23:54:16.968317Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "460"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:22 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5b200fd4-0880-40c5-81a0-9d20553b8e72
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/3725e6f2-c7b0-44b0-8306-c76e2fd1e9ca
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:22 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fa144c1f-4677-4305-825a-14c549187bed
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/c26f0619-02d2-4e47-9125-d2ea307476de
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:22 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 68ee923c-ebec-422b-bc52-bdc36faae782
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d0672d86-a469-4e2e-82dd-7923d7e22813
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:22 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 62609ba4-21e7-416b-8f40-c90401f4964b
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/be0aba55-1a40-406f-8010-cf483a8f6018
+    method: DELETE
+  response:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_snapshot",
+      "resource_id": "be0aba55-1a40-406f-8010-cf483a8f6018"}'
+    headers:
+      Content-Length:
+      - "145"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:22 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 36274590-1a7e-472e-af13-ec7daaaa923c
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/be0aba55-1a40-406f-8010-cf483a8f6018
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 03 Jul 2025 23:54:22 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fa4e687a-9fe0-4d6e-92e7-5d099b778503
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/api/instance/v1/testdata/create-server-image-label-resolution.yaml
+++ b/api/instance/v1/testdata/create-server-image-label-resolution.yaml
@@ -19,9 +19,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:32 GMT
+      - Fri, 04 Jul 2025 14:37:00 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -29,12 +29,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82343e82-53d6-4f01-bb0e-83721849b5d2
+      - 82941a30-d7fc-452b-a164-d1f08c0e1f37
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"srv-quirky-wing","commercial_type":"GP1-XS","image":"c5c72a76-0e9b-437b-a6c9-980d7163c152","project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
+    body: '{"name":"srv-cool-morse","commercial_type":"GP1-XS","image":"c5c72a76-0e9b-437b-a6c9-980d7163c152","project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
     form: {}
     headers:
       Content-Type:
@@ -44,44 +44,44 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "81887650-5403-4e37-910d-1cfa6bad0b09", "name": "srv-quirky-wing",
+    body: '{"server": {"id": "8a758f2e-6a09-46da-9657-c0862af587ce", "name": "srv-cool-morse",
       "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "hostname": "srv-quirky-wing", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
+      "hostname": "srv-cool-morse", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
       "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "c9aa87c7-29a5-4f6c-a4ec-38013b0c12f8",
       "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T12:56:49.762531+00:00",
       "modification_date": "2025-06-25T12:56:49.762531+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "24791535-cc10-48e2-ba99-0232a95dc7f0",
+      "volumes": {"0": {"boot": false, "id": "fc13a5ec-9db9-47d8-9506-ad55a2f0df5f",
       "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "export_uri": null,
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "server": {"id": "81887650-5403-4e37-910d-1cfa6bad0b09", "name": "srv-quirky-wing"},
-      "size": 150000000000, "state": "available", "creation_date": "2025-07-03T23:53:33.021791+00:00",
-      "modification_date": "2025-07-03T23:53:33.021791+00:00", "tags": [], "zone":
+      "server": {"id": "8a758f2e-6a09-46da-9657-c0862af587ce", "name": "srv-cool-morse"},
+      "size": 150000000000, "state": "available", "creation_date": "2025-07-04T14:37:01.023052+00:00",
+      "modification_date": "2025-07-04T14:37:01.023052+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:9b",
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:35:7f",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:53:33.021791+00:00",
-      "modification_date": "2025-07-03T23:53:33.021791+00:00", "bootscript": null,
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-04T14:37:01.023052+00:00",
+      "modification_date": "2025-07-04T14:37:01.023052+00:00", "bootscript": null,
       "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
       "filesystems": [], "end_of_service": false}}'
     headers:
       Content-Length:
-      - "2142"
+      - "2139"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:33 GMT
+      - Fri, 04 Jul 2025 14:37:01 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/81887650-5403-4e37-910d-1cfa6bad0b09
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8a758f2e-6a09-46da-9657-c0862af587ce
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -89,7 +89,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eccabf8e-26af-40d6-8d00-6208b779b725
+      - b59a28a5-0ce1-4a31-af32-f38084801ff1
     status: 201 Created
     code: 201
     duration: ""
@@ -111,9 +111,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:33 GMT
+      - Fri, 04 Jul 2025 14:37:01 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -121,7 +121,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2df43f94-34d9-48f9-8aca-4cfb7ae75b29
+      - 010e04a6-51aa-4cc8-8879-d4151e0af723
     status: 200 OK
     code: 200
     duration: ""
@@ -131,45 +131,45 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/81887650-5403-4e37-910d-1cfa6bad0b09
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8a758f2e-6a09-46da-9657-c0862af587ce
     method: GET
   response:
-    body: '{"server": {"id": "81887650-5403-4e37-910d-1cfa6bad0b09", "name": "srv-quirky-wing",
+    body: '{"server": {"id": "8a758f2e-6a09-46da-9657-c0862af587ce", "name": "srv-cool-morse",
       "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "hostname": "srv-quirky-wing", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
+      "hostname": "srv-cool-morse", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
       "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "c9aa87c7-29a5-4f6c-a4ec-38013b0c12f8",
       "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T12:56:49.762531+00:00",
       "modification_date": "2025-06-25T12:56:49.762531+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "24791535-cc10-48e2-ba99-0232a95dc7f0",
+      "volumes": {"0": {"boot": false, "id": "fc13a5ec-9db9-47d8-9506-ad55a2f0df5f",
       "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "export_uri": null,
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "server": {"id": "81887650-5403-4e37-910d-1cfa6bad0b09", "name": "srv-quirky-wing"},
-      "size": 150000000000, "state": "available", "creation_date": "2025-07-03T23:53:33.021791+00:00",
-      "modification_date": "2025-07-03T23:53:33.021791+00:00", "tags": [], "zone":
+      "server": {"id": "8a758f2e-6a09-46da-9657-c0862af587ce", "name": "srv-cool-morse"},
+      "size": 150000000000, "state": "available", "creation_date": "2025-07-04T14:37:01.023052+00:00",
+      "modification_date": "2025-07-04T14:37:01.023052+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:9b",
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:35:7f",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:53:33.021791+00:00",
-      "modification_date": "2025-07-03T23:53:33.021791+00:00", "bootscript": null,
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-04T14:37:01.023052+00:00",
+      "modification_date": "2025-07-04T14:37:01.023052+00:00", "bootscript": null,
       "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
       "filesystems": [], "end_of_service": false}}'
     headers:
       Content-Length:
-      - "2142"
+      - "2139"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:33 GMT
+      - Fri, 04 Jul 2025 14:37:01 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -177,7 +177,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9d03b16-51a5-419b-be9a-82965008d9bb
+      - 56315ea8-ea47-4a80-8f0d-14a2be15b302
     status: 200 OK
     code: 200
     duration: ""
@@ -187,7 +187,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/81887650-5403-4e37-910d-1cfa6bad0b09
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8a758f2e-6a09-46da-9657-c0862af587ce
     method: DELETE
   response:
     body: ""
@@ -197,9 +197,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:33 GMT
+      - Fri, 04 Jul 2025 14:37:01 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -207,7 +207,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ca50f0e-63bd-4d6e-b1d8-ef3966ef6b35
+      - 0b609068-d629-4c62-8653-a58ab835059c
     status: 204 No Content
     code: 204
     duration: ""
@@ -217,7 +217,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/24791535-cc10-48e2-ba99-0232a95dc7f0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/fc13a5ec-9db9-47d8-9506-ad55a2f0df5f
     method: DELETE
   response:
     body: ""
@@ -227,9 +227,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:33 GMT
+      - Fri, 04 Jul 2025 14:37:01 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -237,7 +237,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36b3f021-ea27-4410-81e4-19712306a086
+      - 1e952bc0-eeb1-47c2-84d9-5ecaa7e378a3
     status: 204 No Content
     code: 204
     duration: ""
@@ -259,9 +259,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:33 GMT
+      - Fri, 04 Jul 2025 14:37:01 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -269,12 +269,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21a3eba7-3d2a-48dc-8c4b-c9661c22ac36
+      - 7602303b-69e2-4915-aa6f-ec3c01e5d77f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"srv-gifted-rosalind","commercial_type":"GP1-XS","image":"95ec2a11-243f-4feb-8efa-155594e2c201","volumes":{"0":{"size":15000000000,"volume_type":"sbs_volume"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
+    body: '{"name":"srv-magical-rosalind","commercial_type":"GP1-XS","image":"95ec2a11-243f-4feb-8efa-155594e2c201","volumes":{"0":{"size":15000000000,"volume_type":"sbs_volume"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
     form: {}
     headers:
       Content-Type:
@@ -284,10 +284,10 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "f2c898df-0cf8-4b12-802f-2faf7c488ab5", "name": "srv-gifted-rosalind",
+    body: '{"server": {"id": "7edfc8d1-7ac7-4ef1-bdbb-bae24535e567", "name": "srv-magical-rosalind",
       "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "hostname": "srv-gifted-rosalind", "image": {"id": "95ec2a11-243f-4feb-8efa-155594e2c201",
+      "hostname": "srv-magical-rosalind", "image": {"id": "95ec2a11-243f-4feb-8efa-155594e2c201",
       "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
       "sbs_snapshot", "id": "e9dae602-1f3d-44c3-b377-a6aed7af0e7e", "size": 0, "name":
@@ -295,29 +295,29 @@ interactions:
       "2025-06-25T12:56:03.466236+00:00", "modification_date": "2025-06-25T12:56:03.466236+00:00",
       "default_bootscript": null, "from_server": "", "state": "available", "tags":
       [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
-      "id": "9fdfc18e-d0fb-4b98-8da2-586420a5df5f", "zone": "fr-par-1"}}, "tags":
+      "id": "72e86764-8873-4376-bf4f-e2f940309d96", "zone": "fr-par-1"}}, "tags":
       [], "state": "stopped", "protected": false, "state_detail": "", "public_ip":
-      null, "public_ips": [], "mac_address": "de:00:00:bb:08:9d", "routed_ip_enabled":
+      null, "public_ips": [], "mac_address": "de:00:00:bb:35:81", "routed_ip_enabled":
       true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6":
-      false, "private_ip": null, "creation_date": "2025-07-03T23:53:34.061596+00:00",
-      "modification_date": "2025-07-03T23:53:34.061596+00:00", "bootscript": null,
+      false, "private_ip": null, "creation_date": "2025-07-04T14:37:02.071581+00:00",
+      "modification_date": "2025-07-04T14:37:02.071581+00:00", "bootscript": null,
       "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
       "filesystems": [], "end_of_service": false}}'
     headers:
       Content-Length:
-      - "1712"
+      - "1714"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:34 GMT
+      - Fri, 04 Jul 2025 14:37:02 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2c898df-0cf8-4b12-802f-2faf7c488ab5
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7edfc8d1-7ac7-4ef1-bdbb-bae24535e567
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -325,7 +325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1914587-52b6-4d3c-8d63-01ee70c91d65
+      - ec2f861d-5988-4172-a163-703cd9b4b56a
     status: 201 Created
     code: 201
     duration: ""
@@ -347,9 +347,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:34 GMT
+      - Fri, 04 Jul 2025 14:37:02 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -357,7 +357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9232b77-e8f4-4372-aa04-d0e0c6d43fa7
+      - c0ce96e3-7ebb-4eaa-90a8-6f55427087da
     status: 200 OK
     code: 200
     duration: ""
@@ -367,13 +367,13 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2c898df-0cf8-4b12-802f-2faf7c488ab5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7edfc8d1-7ac7-4ef1-bdbb-bae24535e567
     method: GET
   response:
-    body: '{"server": {"id": "f2c898df-0cf8-4b12-802f-2faf7c488ab5", "name": "srv-gifted-rosalind",
+    body: '{"server": {"id": "7edfc8d1-7ac7-4ef1-bdbb-bae24535e567", "name": "srv-magical-rosalind",
       "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "hostname": "srv-gifted-rosalind", "image": {"id": "95ec2a11-243f-4feb-8efa-155594e2c201",
+      "hostname": "srv-magical-rosalind", "image": {"id": "95ec2a11-243f-4feb-8efa-155594e2c201",
       "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
       "sbs_snapshot", "id": "e9dae602-1f3d-44c3-b377-a6aed7af0e7e", "size": 0, "name":
@@ -381,27 +381,27 @@ interactions:
       "2025-06-25T12:56:03.466236+00:00", "modification_date": "2025-06-25T12:56:03.466236+00:00",
       "default_bootscript": null, "from_server": "", "state": "available", "tags":
       [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
-      "id": "9fdfc18e-d0fb-4b98-8da2-586420a5df5f", "zone": "fr-par-1"}}, "tags":
+      "id": "72e86764-8873-4376-bf4f-e2f940309d96", "zone": "fr-par-1"}}, "tags":
       [], "state": "stopped", "protected": false, "state_detail": "", "public_ip":
-      null, "public_ips": [], "mac_address": "de:00:00:bb:08:9d", "routed_ip_enabled":
+      null, "public_ips": [], "mac_address": "de:00:00:bb:35:81", "routed_ip_enabled":
       true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6":
-      false, "private_ip": null, "creation_date": "2025-07-03T23:53:34.061596+00:00",
-      "modification_date": "2025-07-03T23:53:34.061596+00:00", "bootscript": null,
+      false, "private_ip": null, "creation_date": "2025-07-04T14:37:02.071581+00:00",
+      "modification_date": "2025-07-04T14:37:02.071581+00:00", "bootscript": null,
       "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
       "filesystems": [], "end_of_service": false}}'
     headers:
       Content-Length:
-      - "1712"
+      - "1714"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:34 GMT
+      - Fri, 04 Jul 2025 14:37:02 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -409,7 +409,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65638727-71ed-4948-b088-f9a2a6815afd
+      - 728655f9-cb84-4125-b58b-fbe454f4b353
     status: 200 OK
     code: 200
     duration: ""
@@ -419,7 +419,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f2c898df-0cf8-4b12-802f-2faf7c488ab5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7edfc8d1-7ac7-4ef1-bdbb-bae24535e567
     method: DELETE
   response:
     body: ""
@@ -429,9 +429,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:35 GMT
+      - Fri, 04 Jul 2025 14:37:03 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -439,7 +439,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5aaf6359-91ba-4629-a272-6fceaf9d61c2
+      - 9577c5c5-25ee-4f73-b9ac-f33cc781bf4f
     status: 204 No Content
     code: 204
     duration: ""
@@ -449,22 +449,22 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9fdfc18e-d0fb-4b98-8da2-586420a5df5f
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/72e86764-8873-4376-bf4f-e2f940309d96
     method: GET
   response:
-    body: '{"id":"9fdfc18e-d0fb-4b98-8da2-586420a5df5f","name":"Ubuntu 24.04 Noble
-      Numbat_sbs_volume_0","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:34.184488Z","updated_at":"2025-07-03T23:53:34.184488Z","references":[{"id":"e2e1349e-2378-4568-8e2e-4e406883266d","product_resource_type":"instance_server","product_resource_id":"f2c898df-0cf8-4b12-802f-2faf7c488ab5","created_at":"2025-07-03T23:53:34.184488Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":"e9dae602-1f3d-44c3-b377-a6aed7af0e7e","status":"in_use","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    body: '{"id":"72e86764-8873-4376-bf4f-e2f940309d96","name":"Ubuntu 24.04 Noble
+      Numbat_sbs_volume_0","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:02.214431Z","updated_at":"2025-07-04T14:37:02.214431Z","references":[{"id":"3bb2ecd2-8311-4fbf-8943-46384e7d3400","product_resource_type":"instance_server","product_resource_id":"7edfc8d1-7ac7-4ef1-bdbb-bae24535e567","created_at":"2025-07-04T14:37:02.214431Z","type":"exclusive","status":"detaching"}],"parent_snapshot_id":"e9dae602-1f3d-44c3-b377-a6aed7af0e7e","status":"in_use","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "683"
+      - "684"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:35 GMT
+      - Fri, 04 Jul 2025 14:37:03 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -472,7 +472,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 524a2751-904c-4e16-a4c6-e30212aa2893
+      - c1dbe9e9-db07-4bfb-8136-de51ed3f3567
     status: 200 OK
     code: 200
     duration: ""
@@ -482,11 +482,11 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9fdfc18e-d0fb-4b98-8da2-586420a5df5f
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/72e86764-8873-4376-bf4f-e2f940309d96
     method: GET
   response:
-    body: '{"id":"9fdfc18e-d0fb-4b98-8da2-586420a5df5f","name":"Ubuntu 24.04 Noble
-      Numbat_sbs_volume_0","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:34.184488Z","updated_at":"2025-07-03T23:53:35.276029Z","references":[],"parent_snapshot_id":"e9dae602-1f3d-44c3-b377-a6aed7af0e7e","status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-07-03T23:53:35.276029Z","zone":"fr-par-1"}'
+    body: '{"id":"72e86764-8873-4376-bf4f-e2f940309d96","name":"Ubuntu 24.04 Noble
+      Numbat_sbs_volume_0","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:02.214431Z","updated_at":"2025-07-04T14:37:03.341832Z","references":[],"parent_snapshot_id":"e9dae602-1f3d-44c3-b377-a6aed7af0e7e","status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-07-04T14:37:03.341832Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "481"
@@ -495,9 +495,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:40 GMT
+      - Fri, 04 Jul 2025 14:37:08 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -505,7 +505,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f30084a-cebb-4e11-9547-f907caf8701c
+      - 19a9605c-6441-4f35-873a-d97fded2b02d
     status: 200 OK
     code: 200
     duration: ""
@@ -515,7 +515,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9fdfc18e-d0fb-4b98-8da2-586420a5df5f
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/72e86764-8873-4376-bf4f-e2f940309d96
     method: DELETE
   response:
     body: ""
@@ -525,9 +525,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:40 GMT
+      - Fri, 04 Jul 2025 14:37:08 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed623825-54c9-45e2-b576-e2f849b9b204
+      - f49ea0a4-af61-4842-af52-e70455dfbba6
     status: 204 No Content
     code: 204
     duration: ""
@@ -557,9 +557,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:40 GMT
+      - Fri, 04 Jul 2025 14:37:08 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -567,12 +567,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29ca3b6c-25f5-41fd-baf6-49ab5ff470b6
+      - 96924fb6-68d3-4a44-bd63-c77bab85ceb8
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"srv-mystifying-ardinghelli","commercial_type":"GP1-XS","image":"c5c72a76-0e9b-437b-a6c9-980d7163c152","volumes":{"0":{"size":15000000000,"volume_type":"l_ssd"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
+    body: '{"name":"srv-beautiful-cerf","commercial_type":"GP1-XS","image":"c5c72a76-0e9b-437b-a6c9-980d7163c152","volumes":{"0":{"size":15000000000,"volume_type":"l_ssd"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
     form: {}
     headers:
       Content-Type:
@@ -582,44 +582,44 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "1c73d5ef-57a6-4896-9fb0-4290d8fff8ae", "name": "srv-mystifying-ardinghelli",
+    body: '{"server": {"id": "7762643f-3844-4d7f-b299-863a262a31cf", "name": "srv-beautiful-cerf",
       "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "hostname": "srv-mystifying-ardinghelli", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
+      "hostname": "srv-beautiful-cerf", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
       "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "c9aa87c7-29a5-4f6c-a4ec-38013b0c12f8",
       "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T12:56:49.762531+00:00",
       "modification_date": "2025-06-25T12:56:49.762531+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "62032e23-f4f0-4fe4-9611-ef0e5f1c6052",
+      "volumes": {"0": {"boot": false, "id": "56a79735-c412-439b-b532-278e8e5922cc",
       "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "export_uri": null,
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "server": {"id": "1c73d5ef-57a6-4896-9fb0-4290d8fff8ae", "name": "srv-mystifying-ardinghelli"},
-      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:53:40.686852+00:00",
-      "modification_date": "2025-07-03T23:53:40.686852+00:00", "tags": [], "zone":
+      "server": {"id": "7762643f-3844-4d7f-b299-863a262a31cf", "name": "srv-beautiful-cerf"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-04T14:37:08.712107+00:00",
+      "modification_date": "2025-07-04T14:37:08.712107+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:9f",
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:35:83",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:53:40.686852+00:00",
-      "modification_date": "2025-07-03T23:53:40.686852+00:00", "bootscript": null,
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-04T14:37:08.712107+00:00",
+      "modification_date": "2025-07-04T14:37:08.712107+00:00", "bootscript": null,
       "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
       "filesystems": [], "end_of_service": false}}'
     headers:
       Content-Length:
-      - "2174"
+      - "2150"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:40 GMT
+      - Fri, 04 Jul 2025 14:37:08 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1c73d5ef-57a6-4896-9fb0-4290d8fff8ae
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7762643f-3844-4d7f-b299-863a262a31cf
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4feab6b-1b85-4c6d-9174-b7f5cde67db2
+      - 539a8bc6-7d2b-49ee-a160-fe9002382678
     status: 201 Created
     code: 201
     duration: ""
@@ -649,9 +649,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:40 GMT
+      - Fri, 04 Jul 2025 14:37:09 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -659,7 +659,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7905b3fb-cdde-4628-90cf-1467c0b77af9
+      - 5c397415-4b88-4a54-abb4-bd8a4be508c9
     status: 200 OK
     code: 200
     duration: ""
@@ -669,45 +669,45 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1c73d5ef-57a6-4896-9fb0-4290d8fff8ae
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7762643f-3844-4d7f-b299-863a262a31cf
     method: GET
   response:
-    body: '{"server": {"id": "1c73d5ef-57a6-4896-9fb0-4290d8fff8ae", "name": "srv-mystifying-ardinghelli",
+    body: '{"server": {"id": "7762643f-3844-4d7f-b299-863a262a31cf", "name": "srv-beautiful-cerf",
       "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "hostname": "srv-mystifying-ardinghelli", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
+      "hostname": "srv-beautiful-cerf", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
       "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "c9aa87c7-29a5-4f6c-a4ec-38013b0c12f8",
       "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T12:56:49.762531+00:00",
       "modification_date": "2025-06-25T12:56:49.762531+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "62032e23-f4f0-4fe4-9611-ef0e5f1c6052",
+      "volumes": {"0": {"boot": false, "id": "56a79735-c412-439b-b532-278e8e5922cc",
       "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "export_uri": null,
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "server": {"id": "1c73d5ef-57a6-4896-9fb0-4290d8fff8ae", "name": "srv-mystifying-ardinghelli"},
-      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:53:40.686852+00:00",
-      "modification_date": "2025-07-03T23:53:40.686852+00:00", "tags": [], "zone":
+      "server": {"id": "7762643f-3844-4d7f-b299-863a262a31cf", "name": "srv-beautiful-cerf"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-04T14:37:08.712107+00:00",
+      "modification_date": "2025-07-04T14:37:08.712107+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:9f",
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:35:83",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:53:40.686852+00:00",
-      "modification_date": "2025-07-03T23:53:40.686852+00:00", "bootscript": null,
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-04T14:37:08.712107+00:00",
+      "modification_date": "2025-07-04T14:37:08.712107+00:00", "bootscript": null,
       "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
       "filesystems": [], "end_of_service": false}}'
     headers:
       Content-Length:
-      - "2174"
+      - "2150"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:41 GMT
+      - Fri, 04 Jul 2025 14:37:09 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -715,7 +715,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bac9870a-0727-45e0-a7e0-1d3059e1aa7d
+      - 48751013-bd14-44bb-9a78-896d9e314f20
     status: 200 OK
     code: 200
     duration: ""
@@ -725,7 +725,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1c73d5ef-57a6-4896-9fb0-4290d8fff8ae
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/7762643f-3844-4d7f-b299-863a262a31cf
     method: DELETE
   response:
     body: ""
@@ -735,9 +735,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:41 GMT
+      - Fri, 04 Jul 2025 14:37:09 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -745,7 +745,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d78745c3-55e5-4147-a17b-32b8f7c8e5d3
+      - 8494efa9-ec91-486d-a586-cebc217c0ab6
     status: 204 No Content
     code: 204
     duration: ""
@@ -755,7 +755,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/62032e23-f4f0-4fe4-9611-ef0e5f1c6052
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/56a79735-c412-439b-b532-278e8e5922cc
     method: DELETE
   response:
     body: ""
@@ -765,9 +765,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:41 GMT
+      - Fri, 04 Jul 2025 14:37:09 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -775,12 +775,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df70b857-948c-4212-878f-a07d4844e6e7
+      - 80c9550f-46c1-4160-9f87-d9c6221a9683
     status: 204 No Content
     code: 204
     duration: ""
 - request:
-    body: '{"name":"vol-jovial-visvesvaraya","perf_iops":5000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","from_empty":{"size":15000000000},"tags":null}'
+    body: '{"name":"vol-romantic-galileo","perf_iops":5000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","from_empty":{"size":15000000000},"tags":null}'
     form: {}
     headers:
       Content-Type:
@@ -790,18 +790,18 @@ interactions:
     url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
     method: POST
   response:
-    body: '{"id":"cf697d2b-bc1e-4356-a317-74b2d91a3642","name":"vol-jovial-visvesvaraya","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:41.373059Z","updated_at":"2025-07-03T23:53:41.373059Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    body: '{"id":"52c51489-c8b6-4cae-b736-490dada0a583","name":"vol-romantic-galileo","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:09.437291Z","updated_at":"2025-07-04T14:37:09.437291Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "406"
+      - "403"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:41 GMT
+      - Fri, 04 Jul 2025 14:37:09 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -809,7 +809,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1efde6e5-e2cb-4d8a-8537-c07558545b67
+      - 0849b6d4-c597-418b-9e75-5e891858c225
     status: 200 OK
     code: 200
     duration: ""
@@ -819,21 +819,21 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/cf697d2b-bc1e-4356-a317-74b2d91a3642
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/52c51489-c8b6-4cae-b736-490dada0a583
     method: GET
   response:
-    body: '{"id":"cf697d2b-bc1e-4356-a317-74b2d91a3642","name":"vol-jovial-visvesvaraya","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:41.373059Z","updated_at":"2025-07-03T23:53:41.373059Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    body: '{"id":"52c51489-c8b6-4cae-b736-490dada0a583","name":"vol-romantic-galileo","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:09.437291Z","updated_at":"2025-07-04T14:37:09.437291Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "406"
+      - "403"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:41 GMT
+      - Fri, 04 Jul 2025 14:37:09 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -841,7 +841,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67b6dde6-3920-4891-982a-8a80528a0baa
+      - b2cf40a3-85f5-4693-8976-67b8fe3181ad
     status: 200 OK
     code: 200
     duration: ""
@@ -851,21 +851,21 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/cf697d2b-bc1e-4356-a317-74b2d91a3642
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/52c51489-c8b6-4cae-b736-490dada0a583
     method: GET
   response:
-    body: '{"id":"cf697d2b-bc1e-4356-a317-74b2d91a3642","name":"vol-jovial-visvesvaraya","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:41.373059Z","updated_at":"2025-07-03T23:53:41.373059Z","references":[],"parent_snapshot_id":null,"status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    body: '{"id":"52c51489-c8b6-4cae-b736-490dada0a583","name":"vol-romantic-galileo","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:09.437291Z","updated_at":"2025-07-04T14:37:09.437291Z","references":[],"parent_snapshot_id":null,"status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "407"
+      - "404"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:46 GMT
+      - Fri, 04 Jul 2025 14:37:14 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -873,12 +873,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce9acce2-20e7-457e-9475-5a3d70c30a50
+      - 45dae0dd-781b-4c6a-a433-eb9ce1d01b3e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"volume_id":"cf697d2b-bc1e-4356-a317-74b2d91a3642","name":"snp-confident-elgamal","project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":null}'
+    body: '{"volume_id":"52c51489-c8b6-4cae-b736-490dada0a583","name":"snp-flamboyant-beaver","project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":null}'
     form: {}
     headers:
       Content-Type:
@@ -888,18 +888,18 @@ interactions:
     url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots
     method: POST
   response:
-    body: '{"id":"6d3f9df3-60b1-4bd0-8c80-aed482c01140","name":"snp-confident-elgamal","parent_volume":{"id":"cf697d2b-bc1e-4356-a317-74b2d91a3642","name":"vol-jovial-visvesvaraya","type":"sbs_5k","status":"available"},"size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:46.596910Z","updated_at":"2025-07-03T23:53:46.596910Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    body: '{"id":"2d57a339-9681-47da-ba63-f682969f2aa5","name":"snp-flamboyant-beaver","parent_volume":{"id":"52c51489-c8b6-4cae-b736-490dada0a583","name":"vol-romantic-galileo","type":"sbs_5k","status":"available"},"size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:14.685776Z","updated_at":"2025-07-04T14:37:14.685776Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "443"
+      - "440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:46 GMT
+      - Fri, 04 Jul 2025 14:37:15 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -907,7 +907,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ec5781d-dd66-4448-bc64-b32468d76412
+      - 7d58ebfb-02f8-47b9-b481-b79307a40b80
     status: 200 OK
     code: 200
     duration: ""
@@ -917,21 +917,21 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/6d3f9df3-60b1-4bd0-8c80-aed482c01140
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/2d57a339-9681-47da-ba63-f682969f2aa5
     method: GET
   response:
-    body: '{"id":"6d3f9df3-60b1-4bd0-8c80-aed482c01140","name":"snp-confident-elgamal","parent_volume":{"id":"cf697d2b-bc1e-4356-a317-74b2d91a3642","name":"vol-jovial-visvesvaraya","type":"sbs_5k","status":"available"},"size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:46.596910Z","updated_at":"2025-07-03T23:53:46.596910Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    body: '{"id":"2d57a339-9681-47da-ba63-f682969f2aa5","name":"snp-flamboyant-beaver","parent_volume":{"id":"52c51489-c8b6-4cae-b736-490dada0a583","name":"vol-romantic-galileo","type":"sbs_5k","status":"available"},"size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:14.685776Z","updated_at":"2025-07-04T14:37:14.685776Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "443"
+      - "440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:46 GMT
+      - Fri, 04 Jul 2025 14:37:15 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -939,7 +939,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 079891de-e3c5-4a1f-a596-7793a31c6f34
+      - b8890f18-9bec-488c-9fb1-8daf4bf1f34d
     status: 200 OK
     code: 200
     duration: ""
@@ -949,21 +949,21 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/6d3f9df3-60b1-4bd0-8c80-aed482c01140
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/2d57a339-9681-47da-ba63-f682969f2aa5
     method: GET
   response:
-    body: '{"id":"6d3f9df3-60b1-4bd0-8c80-aed482c01140","name":"snp-confident-elgamal","parent_volume":{"id":"cf697d2b-bc1e-4356-a317-74b2d91a3642","name":"vol-jovial-visvesvaraya","type":"sbs_5k","status":"available"},"size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:46.596910Z","updated_at":"2025-07-03T23:53:46.596910Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    body: '{"id":"2d57a339-9681-47da-ba63-f682969f2aa5","name":"snp-flamboyant-beaver","parent_volume":{"id":"52c51489-c8b6-4cae-b736-490dada0a583","name":"vol-romantic-galileo","type":"sbs_5k","status":"available"},"size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:14.685776Z","updated_at":"2025-07-04T14:37:14.685776Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "444"
+      - "441"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:52 GMT
+      - Fri, 04 Jul 2025 14:37:20 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -971,7 +971,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 490cee95-7d3d-4e44-a902-736dc4ffadd3
+      - 87c0b123-eafb-4899-bf0b-71139591cb20
     status: 200 OK
     code: 200
     duration: ""
@@ -981,7 +981,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/cf697d2b-bc1e-4356-a317-74b2d91a3642
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/52c51489-c8b6-4cae-b736-490dada0a583
     method: DELETE
   response:
     body: ""
@@ -991,9 +991,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:52 GMT
+      - Fri, 04 Jul 2025 14:37:20 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1001,7 +1001,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d815054-66d6-4f9c-a0b2-66fba9708338
+      - 810e9b06-d9de-4fab-b902-fb1f946c447a
     status: 204 No Content
     code: 204
     duration: ""
@@ -1023,9 +1023,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:52 GMT
+      - Fri, 04 Jul 2025 14:37:20 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1033,12 +1033,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ef5ff6c-fccf-49b3-9e7c-e38a2319056e
+      - 177cb6b9-aebd-4cb7-8f06-1d04ce1e3004
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"srv-funny-khorana","commercial_type":"GP1-XS","image":"95ec2a11-243f-4feb-8efa-155594e2c201","volumes":{"0":{"name":"sbs-volume-from-snap","volume_type":"sbs_volume","base_snapshot":"6d3f9df3-60b1-4bd0-8c80-aed482c01140"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
+    body: '{"name":"srv-magical-herschel","commercial_type":"GP1-XS","image":"95ec2a11-243f-4feb-8efa-155594e2c201","volumes":{"0":{"name":"sbs-volume-from-snap","volume_type":"sbs_volume","base_snapshot":"2d57a339-9681-47da-ba63-f682969f2aa5"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
     form: {}
     headers:
       Content-Type:
@@ -1048,10 +1048,10 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "8ccba46a-4b89-4277-a662-e46949a0f0fb", "name": "srv-funny-khorana",
+    body: '{"server": {"id": "f0c9bc3f-f409-46f0-8384-90883d80140c", "name": "srv-magical-herschel",
       "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "hostname": "srv-funny-khorana", "image": {"id": "95ec2a11-243f-4feb-8efa-155594e2c201",
+      "hostname": "srv-magical-herschel", "image": {"id": "95ec2a11-243f-4feb-8efa-155594e2c201",
       "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
       "sbs_snapshot", "id": "e9dae602-1f3d-44c3-b377-a6aed7af0e7e", "size": 0, "name":
@@ -1059,29 +1059,29 @@ interactions:
       "2025-06-25T12:56:03.466236+00:00", "modification_date": "2025-06-25T12:56:03.466236+00:00",
       "default_bootscript": null, "from_server": "", "state": "available", "tags":
       [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
-      "id": "c110b37a-2547-4d64-b71f-5edcda74197a", "zone": "fr-par-1"}}, "tags":
+      "id": "7a5eaf0f-e30b-4acf-866f-334648b20bc7", "zone": "fr-par-1"}}, "tags":
       [], "state": "stopped", "protected": false, "state_detail": "", "public_ip":
-      null, "public_ips": [], "mac_address": "de:00:00:bb:08:a7", "routed_ip_enabled":
+      null, "public_ips": [], "mac_address": "de:00:00:bb:35:87", "routed_ip_enabled":
       true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6":
-      false, "private_ip": null, "creation_date": "2025-07-03T23:53:52.404140+00:00",
-      "modification_date": "2025-07-03T23:53:52.404140+00:00", "bootscript": null,
+      false, "private_ip": null, "creation_date": "2025-07-04T14:37:20.833977+00:00",
+      "modification_date": "2025-07-04T14:37:20.833977+00:00", "bootscript": null,
       "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
       "filesystems": [], "end_of_service": false}}'
     headers:
       Content-Length:
-      - "1708"
+      - "1714"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:52 GMT
+      - Fri, 04 Jul 2025 14:37:21 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ccba46a-4b89-4277-a662-e46949a0f0fb
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f0c9bc3f-f409-46f0-8384-90883d80140c
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1089,7 +1089,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d137ec9b-4a3f-4650-a7f1-044b1df96d5c
+      - d9fbc220-87d1-4ceb-bf64-ed42cdaf4a26
     status: 201 Created
     code: 201
     duration: ""
@@ -1111,9 +1111,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:52 GMT
+      - Fri, 04 Jul 2025 14:37:21 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1121,7 +1121,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce378aa6-da15-4899-b3c2-bab56d350bfc
+      - 6b5d4827-cec9-47da-9b41-cd3d345859f2
     status: 200 OK
     code: 200
     duration: ""
@@ -1131,13 +1131,13 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ccba46a-4b89-4277-a662-e46949a0f0fb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f0c9bc3f-f409-46f0-8384-90883d80140c
     method: GET
   response:
-    body: '{"server": {"id": "8ccba46a-4b89-4277-a662-e46949a0f0fb", "name": "srv-funny-khorana",
+    body: '{"server": {"id": "f0c9bc3f-f409-46f0-8384-90883d80140c", "name": "srv-magical-herschel",
       "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "hostname": "srv-funny-khorana", "image": {"id": "95ec2a11-243f-4feb-8efa-155594e2c201",
+      "hostname": "srv-magical-herschel", "image": {"id": "95ec2a11-243f-4feb-8efa-155594e2c201",
       "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
       "sbs_snapshot", "id": "e9dae602-1f3d-44c3-b377-a6aed7af0e7e", "size": 0, "name":
@@ -1145,27 +1145,27 @@ interactions:
       "2025-06-25T12:56:03.466236+00:00", "modification_date": "2025-06-25T12:56:03.466236+00:00",
       "default_bootscript": null, "from_server": "", "state": "available", "tags":
       [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
-      "id": "c110b37a-2547-4d64-b71f-5edcda74197a", "zone": "fr-par-1"}}, "tags":
+      "id": "7a5eaf0f-e30b-4acf-866f-334648b20bc7", "zone": "fr-par-1"}}, "tags":
       [], "state": "stopped", "protected": false, "state_detail": "", "public_ip":
-      null, "public_ips": [], "mac_address": "de:00:00:bb:08:a7", "routed_ip_enabled":
+      null, "public_ips": [], "mac_address": "de:00:00:bb:35:87", "routed_ip_enabled":
       true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6":
-      false, "private_ip": null, "creation_date": "2025-07-03T23:53:52.404140+00:00",
-      "modification_date": "2025-07-03T23:53:52.404140+00:00", "bootscript": null,
+      false, "private_ip": null, "creation_date": "2025-07-04T14:37:20.833977+00:00",
+      "modification_date": "2025-07-04T14:37:20.833977+00:00", "bootscript": null,
       "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
       "filesystems": [], "end_of_service": false}}'
     headers:
       Content-Length:
-      - "1708"
+      - "1714"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:53 GMT
+      - Fri, 04 Jul 2025 14:37:21 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1173,7 +1173,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a0473d4-d3fc-49d0-8a43-45eeb3be08e9
+      - 8e8d4ea9-027c-4dc5-92c3-c7b9f53da622
     status: 200 OK
     code: 200
     duration: ""
@@ -1183,7 +1183,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ccba46a-4b89-4277-a662-e46949a0f0fb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f0c9bc3f-f409-46f0-8384-90883d80140c
     method: DELETE
   response:
     body: ""
@@ -1193,9 +1193,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:53 GMT
+      - Fri, 04 Jul 2025 14:37:21 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1203,7 +1203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49590171-e8bd-4d15-bb66-83a66fd85db3
+      - f42e3762-ded5-4f70-bfc4-98b6594d1d39
     status: 204 No Content
     code: 204
     duration: ""
@@ -1213,21 +1213,21 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/c110b37a-2547-4d64-b71f-5edcda74197a
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/7a5eaf0f-e30b-4acf-866f-334648b20bc7
     method: GET
   response:
-    body: '{"id":"c110b37a-2547-4d64-b71f-5edcda74197a","name":"sbs-volume-from-snap","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:52.523668Z","updated_at":"2025-07-03T23:53:52.523668Z","references":[{"id":"635ff0d0-7021-4a31-a5c0-c7abba738996","product_resource_type":"instance_server","product_resource_id":"8ccba46a-4b89-4277-a662-e46949a0f0fb","created_at":"2025-07-03T23:53:52.523668Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":"6d3f9df3-60b1-4bd0-8c80-aed482c01140","status":"in_use","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    body: '{"id":"7a5eaf0f-e30b-4acf-866f-334648b20bc7","name":"sbs-volume-from-snap","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:20.961123Z","updated_at":"2025-07-04T14:37:20.961123Z","references":[{"id":"efa2b180-d198-4498-953d-d5e1d8fff6ed","product_resource_type":"instance_server","product_resource_id":"f0c9bc3f-f409-46f0-8384-90883d80140c","created_at":"2025-07-04T14:37:20.961123Z","type":"exclusive","status":"detaching"}],"parent_snapshot_id":"2d57a339-9681-47da-ba63-f682969f2aa5","status":"in_use","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "665"
+      - "666"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:53 GMT
+      - Fri, 04 Jul 2025 14:37:21 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1235,7 +1235,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49649718-8880-46f4-8853-439551c75299
+      - 6f0fc10c-e6e1-4423-ba79-42666c1f22a2
     status: 200 OK
     code: 200
     duration: ""
@@ -1245,10 +1245,10 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/c110b37a-2547-4d64-b71f-5edcda74197a
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/7a5eaf0f-e30b-4acf-866f-334648b20bc7
     method: GET
   response:
-    body: '{"id":"c110b37a-2547-4d64-b71f-5edcda74197a","name":"sbs-volume-from-snap","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:53:52.523668Z","updated_at":"2025-07-03T23:53:53.348660Z","references":[],"parent_snapshot_id":"6d3f9df3-60b1-4bd0-8c80-aed482c01140","status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-07-03T23:53:53.348660Z","zone":"fr-par-1"}'
+    body: '{"id":"7a5eaf0f-e30b-4acf-866f-334648b20bc7","name":"sbs-volume-from-snap","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:20.961123Z","updated_at":"2025-07-04T14:37:22.009950Z","references":[],"parent_snapshot_id":"2d57a339-9681-47da-ba63-f682969f2aa5","status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-07-04T14:37:22.009950Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "463"
@@ -1257,9 +1257,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:58 GMT
+      - Fri, 04 Jul 2025 14:37:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1267,7 +1267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 437d84d2-01c8-4ce7-b04b-c1d1ee0819e3
+      - 592e24d3-01b7-4f6a-9469-03ad60613a96
     status: 200 OK
     code: 200
     duration: ""
@@ -1277,7 +1277,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/c110b37a-2547-4d64-b71f-5edcda74197a
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/7a5eaf0f-e30b-4acf-866f-334648b20bc7
     method: DELETE
   response:
     body: ""
@@ -1287,9 +1287,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:58 GMT
+      - Fri, 04 Jul 2025 14:37:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1297,7 +1297,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57e3e254-266f-4c63-92d6-861f70bc9420
+      - a886413e-e91b-4f13-9fc2-2d740710e2df
     status: 204 No Content
     code: 204
     duration: ""
@@ -1307,11 +1307,11 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/6d3f9df3-60b1-4bd0-8c80-aed482c01140
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2d57a339-9681-47da-ba63-f682969f2aa5
     method: DELETE
   response:
     body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_snapshot",
-      "resource_id": "6d3f9df3-60b1-4bd0-8c80-aed482c01140"}'
+      "resource_id": "2d57a339-9681-47da-ba63-f682969f2aa5"}'
     headers:
       Content-Length:
       - "145"
@@ -1320,9 +1320,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:58 GMT
+      - Fri, 04 Jul 2025 14:37:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1330,7 +1330,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf9eff8f-014a-4342-8cf4-d97bc22d35ef
+      - 636a31e9-2390-4cc7-a715-a0e96cf9ba3d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1340,7 +1340,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/6d3f9df3-60b1-4bd0-8c80-aed482c01140
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/2d57a339-9681-47da-ba63-f682969f2aa5
     method: DELETE
   response:
     body: ""
@@ -1350,9 +1350,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:58 GMT
+      - Fri, 04 Jul 2025 14:37:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1360,7 +1360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01e80663-efe2-49ae-9e5a-d82fed48a841
+      - c5dc738e-3731-426b-bd5d-91d2854eef8c
     status: 204 No Content
     code: 204
     duration: ""
@@ -1382,9 +1382,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:58 GMT
+      - Fri, 04 Jul 2025 14:37:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1392,12 +1392,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c13480b8-444e-4199-ad03-b8bd66a26cae
+      - c6b7acbb-f71c-4de0-b914-219565dd0f49
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"srv-festive-maxwell","commercial_type":"DEV1-S","image":"4a4d2994-e7e0-4b29-a760-36235e6ba258","volumes":{"0":{"size":15000000000,"volume_type":"l_ssd"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
+    body: '{"name":"srv-pedantic-goodall","commercial_type":"DEV1-S","image":"4a4d2994-e7e0-4b29-a760-36235e6ba258","volumes":{"0":{"size":15000000000,"volume_type":"l_ssd"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
     form: {}
     headers:
       Content-Type:
@@ -1407,44 +1407,44 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "04a07a9e-ed86-4745-9fd9-9c71905047bf", "name": "srv-festive-maxwell",
+    body: '{"server": {"id": "e27d9b4b-3631-499e-bb62-5b0a3b1beb58", "name": "srv-pedantic-goodall",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "hostname": "srv-festive-maxwell", "image": {"id": "4a4d2994-e7e0-4b29-a760-36235e6ba258",
+      "hostname": "srv-pedantic-goodall", "image": {"id": "4a4d2994-e7e0-4b29-a760-36235e6ba258",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "37000787-865a-4306-8ac4-5a0b2e2fcbbe",
       "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:47:39.547126+00:00",
       "modification_date": "2025-06-25T15:47:39.547126+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "800f51c5-d519-485e-a114-9aa7a9c8d20e",
+      "volumes": {"0": {"boot": false, "id": "d068daf9-3c35-4e7c-91b7-f47e9f400ca3",
       "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "export_uri": null,
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "server": {"id": "04a07a9e-ed86-4745-9fd9-9c71905047bf", "name": "srv-festive-maxwell"},
-      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:53:58.968318+00:00",
-      "modification_date": "2025-07-03T23:53:58.968318+00:00", "tags": [], "zone":
+      "server": {"id": "e27d9b4b-3631-499e-bb62-5b0a3b1beb58", "name": "srv-pedantic-goodall"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-04T14:37:27.547294+00:00",
+      "modification_date": "2025-07-04T14:37:27.547294+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:a9",
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:35:89",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:53:58.968318+00:00",
-      "modification_date": "2025-07-03T23:53:58.968318+00:00", "bootscript": null,
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-04T14:37:27.547294+00:00",
+      "modification_date": "2025-07-04T14:37:27.547294+00:00", "bootscript": null,
       "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
       "filesystems": [], "end_of_service": false}}'
     headers:
       Content-Length:
-      - "2150"
+      - "2153"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:53:59 GMT
+      - Fri, 04 Jul 2025 14:37:27 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04a07a9e-ed86-4745-9fd9-9c71905047bf
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e27d9b4b-3631-499e-bb62-5b0a3b1beb58
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1452,12 +1452,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 076cdbc4-ad48-414f-b462-4289b91dfac5
+      - 20308045-d381-44e9-9d38-a44242b11cf1
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"name":"snp-reverent-blackburn","volume_id":"800f51c5-d519-485e-a114-9aa7a9c8d20e","project":"19a4819b-24bf-4d44-969f-935ef0061b71","volume_type":"l_ssd"}'
+    body: '{"name":"snp-upbeat-antonelli","volume_id":"d068daf9-3c35-4e7c-91b7-f47e9f400ca3","project":"19a4819b-24bf-4d44-969f-935ef0061b71","volume_type":"l_ssd"}'
     form: {}
     headers:
       Content-Type:
@@ -1467,874 +1467,15 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
     method: POST
   response:
-    body: '{"snapshot": {"id": "25957e58-ceaa-4ec9-9167-73f06e947699", "name": "snp-reverent-blackburn",
-      "volume_type": "l_ssd", "creation_date": "2025-07-03T23:53:59.254516+00:00",
-      "modification_date": "2025-07-03T23:53:59.254516+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    body: '{"snapshot": {"id": "8abcb0ee-f52c-4142-bc1e-45757160cd3f", "name": "snp-upbeat-antonelli",
+      "volume_type": "l_ssd", "creation_date": "2025-07-04T14:37:27.870447+00:00",
+      "modification_date": "2025-07-04T14:37:27.870447+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
       "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "size": 15000000000, "state":
-      "available", "base_volume": {"id": "800f51c5-d519-485e-a114-9aa7a9c8d20e", "name":
+      "available", "base_volume": {"id": "d068daf9-3c35-4e7c-91b7-f47e9f400ca3", "name":
       "Ubuntu 20.04 Focal Fossa"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}, "task": {"id": "9fd878a6-5d5c-448a-ae1b-3519dd8a9b62", "description":
+      null}, "task": {"id": "3f67c0cd-2d81-4bbe-928b-4ce80bf52643", "description":
       "volume_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
-      "snapshots/25957e58-ceaa-4ec9-9167-73f06e947699", "started_at": "2025-07-03T23:53:59.487341+00:00",
-      "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "843"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:53:59 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 99aa2a6c-7c11-46ac-ad3c-b49144b2469f
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04a07a9e-ed86-4745-9fd9-9c71905047bf
-    method: GET
-  response:
-    body: '{"server": {"id": "04a07a9e-ed86-4745-9fd9-9c71905047bf", "name": "srv-festive-maxwell",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "hostname": "srv-festive-maxwell", "image": {"id": "4a4d2994-e7e0-4b29-a760-36235e6ba258",
-      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "37000787-865a-4306-8ac4-5a0b2e2fcbbe",
-      "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:47:39.547126+00:00",
-      "modification_date": "2025-06-25T15:47:39.547126+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "800f51c5-d519-485e-a114-9aa7a9c8d20e",
-      "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "export_uri": null,
-      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "server": {"id": "04a07a9e-ed86-4745-9fd9-9c71905047bf", "name": "srv-festive-maxwell"},
-      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:53:58.968318+00:00",
-      "modification_date": "2025-07-03T23:53:58.968318+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:a9",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:53:58.968318+00:00",
-      "modification_date": "2025-07-03T23:53:58.968318+00:00", "bootscript": null,
-      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
-      "filesystems": [], "end_of_service": false}}'
-    headers:
-      Content-Length:
-      - "2150"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:53:59 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 85cf846c-0ff1-42f7-843f-8a1aac5aa7d5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04a07a9e-ed86-4745-9fd9-9c71905047bf
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:53:59 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e9449c4e-b9f0-4e71-a1d2-42617fd79a9a
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/800f51c5-d519-485e-a114-9aa7a9c8d20e
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:53:59 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 57b97d97-1ad1-40fc-9268-c9bf6ceed1f5
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_noble&order_by=type_asc&type=instance_local&zone=fr-par-1
-    method: GET
-  response:
-    body: '{"local_images":[{"id":"c5c72a76-0e9b-437b-a6c9-980d7163c152","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","STARDUST1-S","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB"],"label":"ubuntu_noble","type":"instance_local"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "397"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:53:59 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 952a85ff-d27d-4d70-afec-32fb00f59654
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"srv-affectionate-elgamal","commercial_type":"GP1-XS","image":"c5c72a76-0e9b-437b-a6c9-980d7163c152","volumes":{"0":{"name":"local-volume-from-snap","volume_type":"l_ssd","base_snapshot":"25957e58-ceaa-4ec9-9167-73f06e947699"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
-    method: POST
-  response:
-    body: '{"server": {"id": "ed4587e3-a873-4a27-92eb-39dbd03e8070", "name": "srv-affectionate-elgamal",
-      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
-      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "hostname": "srv-affectionate-elgamal", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
-      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "c9aa87c7-29a5-4f6c-a4ec-38013b0c12f8",
-      "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T12:56:49.762531+00:00",
-      "modification_date": "2025-06-25T12:56:49.762531+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "107b9908-8b0a-440e-a401-7dfea41eac4d",
-      "name": "local-volume-from-snap", "volume_type": "l_ssd", "export_uri": null,
-      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "server": {"id": "ed4587e3-a873-4a27-92eb-39dbd03e8070", "name": "srv-affectionate-elgamal"},
-      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:54:00.329514+00:00",
-      "modification_date": "2025-07-03T23:54:00.329514+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:ad",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:54:00.329514+00:00",
-      "modification_date": "2025-07-03T23:54:00.329514+00:00", "bootscript": null,
-      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
-      "filesystems": [], "end_of_service": false}}'
-    headers:
-      Content-Length:
-      - "2165"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:00 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ed4587e3-a873-4a27-92eb-39dbd03e8070
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7273eddd-0377-44e9-8382-1ea3de0850c0
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/marketplace/v2/local-images/c5c72a76-0e9b-437b-a6c9-980d7163c152
-    method: GET
-  response:
-    body: '{"id":"c5c72a76-0e9b-437b-a6c9-980d7163c152","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","STARDUST1-S","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB"],"label":"ubuntu_noble","type":"instance_local"}'
-    headers:
-      Content-Length:
-      - "362"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:00 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5c082187-cbbd-4b2b-b016-b60ac0b7a31b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ed4587e3-a873-4a27-92eb-39dbd03e8070
-    method: GET
-  response:
-    body: '{"server": {"id": "ed4587e3-a873-4a27-92eb-39dbd03e8070", "name": "srv-affectionate-elgamal",
-      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
-      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "hostname": "srv-affectionate-elgamal", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
-      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "c9aa87c7-29a5-4f6c-a4ec-38013b0c12f8",
-      "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T12:56:49.762531+00:00",
-      "modification_date": "2025-06-25T12:56:49.762531+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "107b9908-8b0a-440e-a401-7dfea41eac4d",
-      "name": "local-volume-from-snap", "volume_type": "l_ssd", "export_uri": null,
-      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "server": {"id": "ed4587e3-a873-4a27-92eb-39dbd03e8070", "name": "srv-affectionate-elgamal"},
-      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:54:00.329514+00:00",
-      "modification_date": "2025-07-03T23:54:00.329514+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:ad",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:54:00.329514+00:00",
-      "modification_date": "2025-07-03T23:54:00.329514+00:00", "bootscript": null,
-      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
-      "filesystems": [], "end_of_service": false}}'
-    headers:
-      Content-Length:
-      - "2165"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:01 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e1c0ab22-7757-43ec-94b8-cfd37f3e4fea
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ed4587e3-a873-4a27-92eb-39dbd03e8070
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:01 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1bcc94e7-f457-49be-9941-f0fbea603314
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/107b9908-8b0a-440e-a401-7dfea41eac4d
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:01 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 94c27c09-95bd-43bf-adcb-055bea874252
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/25957e58-ceaa-4ec9-9167-73f06e947699
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:01 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d6e061ef-2826-44b4-bef1-04dc73ae4802
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: '{"name":"vol-vibrant-poitras","perf_iops":5000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","from_empty":{"size":15000000000},"tags":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
-    method: POST
-  response:
-    body: '{"id":"925759ec-00b4-45a8-88a8-bb3503c70e87","name":"vol-vibrant-poitras","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:01.477518Z","updated_at":"2025-07-03T23:54:01.477518Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "402"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:01 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 012bb6a4-e5e7-4c1b-ad61-0f53bb78d7ef
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_noble&order_by=type_asc&type=instance_sbs&zone=fr-par-1
-    method: GET
-  response:
-    body: '{"local_images":[{"id":"95ec2a11-243f-4feb-8efa-155594e2c201","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-48C-192G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-48C-384G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-48C-96G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"label":"ubuntu_noble","type":"instance_sbs"},{"id":"e5758c61-4375-4ce5-b3d5-2f9ffd2b682d","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_noble","type":"instance_sbs"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "1185"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:01 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 74d773fd-a3cd-4fec-84bf-fc0026ce29d2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"srv-sleepy-aryabhata","commercial_type":"GP1-XS","image":"95ec2a11-243f-4feb-8efa-155594e2c201","volumes":{"0":{"name":"empty-root-volume","size":15000000000,"volume_type":"l_ssd"},"1":{"id":"925759ec-00b4-45a8-88a8-bb3503c70e87","boot":true,"volume_type":"sbs_volume"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
-    method: POST
-  response:
-    body: '{"server": {"id": "40b03479-f3a5-4716-a4e9-b30e9fbec971", "name": "srv-sleepy-aryabhata",
-      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
-      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "hostname": "srv-sleepy-aryabhata", "image": {"id": "95ec2a11-243f-4feb-8efa-155594e2c201",
-      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
-      "sbs_snapshot", "id": "e9dae602-1f3d-44c3-b377-a6aed7af0e7e", "size": 0, "name":
-      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
-      "2025-06-25T12:56:03.466236+00:00", "modification_date": "2025-06-25T12:56:03.466236+00:00",
-      "default_bootscript": null, "from_server": "", "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "6c4e901f-d3e2-4129-bf2c-657fc83ed5ec",
-      "name": "empty-root-volume", "volume_type": "l_ssd", "export_uri": null, "organization":
-      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "server": {"id": "40b03479-f3a5-4716-a4e9-b30e9fbec971", "name": "srv-sleepy-aryabhata"},
-      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:54:01.824529+00:00",
-      "modification_date": "2025-07-03T23:54:01.824529+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": true, "volume_type": "sbs_volume", "id": "925759ec-00b4-45a8-88a8-bb3503c70e87",
-      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:af",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:54:01.824529+00:00",
-      "modification_date": "2025-07-03T23:54:01.824529+00:00", "bootscript": null,
-      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
-      "filesystems": [], "end_of_service": false}}'
-    headers:
-      Content-Length:
-      - "2236"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:02 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/40b03479-f3a5-4716-a4e9-b30e9fbec971
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1b469dd7-f605-4501-b857-26cd4168f38f
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/marketplace/v2/local-images/95ec2a11-243f-4feb-8efa-155594e2c201
-    method: GET
-  response:
-    body: '{"id":"95ec2a11-243f-4feb-8efa-155594e2c201","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-48C-192G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-48C-384G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-48C-96G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"label":"ubuntu_noble","type":"instance_sbs"}'
-    headers:
-      Content-Length:
-      - "907"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:02 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9f486c24-a30f-4b0b-85c2-293ed58f9189
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/40b03479-f3a5-4716-a4e9-b30e9fbec971
-    method: GET
-  response:
-    body: '{"server": {"id": "40b03479-f3a5-4716-a4e9-b30e9fbec971", "name": "srv-sleepy-aryabhata",
-      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
-      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "hostname": "srv-sleepy-aryabhata", "image": {"id": "95ec2a11-243f-4feb-8efa-155594e2c201",
-      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
-      "sbs_snapshot", "id": "e9dae602-1f3d-44c3-b377-a6aed7af0e7e", "size": 0, "name":
-      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
-      "2025-06-25T12:56:03.466236+00:00", "modification_date": "2025-06-25T12:56:03.466236+00:00",
-      "default_bootscript": null, "from_server": "", "state": "available", "tags":
-      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "6c4e901f-d3e2-4129-bf2c-657fc83ed5ec",
-      "name": "empty-root-volume", "volume_type": "l_ssd", "export_uri": null, "organization":
-      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "server": {"id": "40b03479-f3a5-4716-a4e9-b30e9fbec971", "name": "srv-sleepy-aryabhata"},
-      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:54:01.824529+00:00",
-      "modification_date": "2025-07-03T23:54:01.824529+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": true, "volume_type": "sbs_volume", "id": "925759ec-00b4-45a8-88a8-bb3503c70e87",
-      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:af",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:54:01.824529+00:00",
-      "modification_date": "2025-07-03T23:54:01.824529+00:00", "bootscript": null,
-      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
-      "filesystems": [], "end_of_service": false}}'
-    headers:
-      Content-Length:
-      - "2236"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:02 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 59e41dd5-cc6e-422b-a610-a71e6316ea57
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/40b03479-f3a5-4716-a4e9-b30e9fbec971
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:03 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7aa2d9e2-1bf2-43aa-a9fe-6ab3c44d013f
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6c4e901f-d3e2-4129-bf2c-657fc83ed5ec
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:03 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3bbae38d-534f-4365-b034-b34a7b72e7f1
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/925759ec-00b4-45a8-88a8-bb3503c70e87
-    method: GET
-  response:
-    body: '{"id":"925759ec-00b4-45a8-88a8-bb3503c70e87","name":"vol-vibrant-poitras","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:01.477518Z","updated_at":"2025-07-03T23:54:03.277848Z","references":[],"parent_snapshot_id":null,"status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-07-03T23:54:03.277848Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "428"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:03 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d8484cee-5fdc-48cb-82ee-70026af22c1a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/925759ec-00b4-45a8-88a8-bb3503c70e87
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:03 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 498e40f7-fb17-41ca-8877-95c1ed4631e0
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
-    method: GET
-  response:
-    body: '{"local_images":[{"id":"4a4d2994-e7e0-4b29-a760-36235e6ba258","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","STARDUST1-S","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB"],"label":"ubuntu_focal","type":"instance_local"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "397"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:03 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - aac18afb-9888-453d-af34-42be8075ebc9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"srv-vigilant-cartwright","commercial_type":"DEV1-S","image":"4a4d2994-e7e0-4b29-a760-36235e6ba258","volumes":{"0":{"size":15000000000,"volume_type":"l_ssd"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
-    method: POST
-  response:
-    body: '{"server": {"id": "d20190a3-a38f-4423-b1c0-c4a16fb89210", "name": "srv-vigilant-cartwright",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "hostname": "srv-vigilant-cartwright", "image": {"id": "4a4d2994-e7e0-4b29-a760-36235e6ba258",
-      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "37000787-865a-4306-8ac4-5a0b2e2fcbbe",
-      "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:47:39.547126+00:00",
-      "modification_date": "2025-06-25T15:47:39.547126+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "f1b7a5e2-6866-4b44-b32b-31f04f396ac0",
-      "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "export_uri": null,
-      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "server": {"id": "d20190a3-a38f-4423-b1c0-c4a16fb89210", "name": "srv-vigilant-cartwright"},
-      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:54:03.672754+00:00",
-      "modification_date": "2025-07-03T23:54:03.672754+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:b1",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:54:03.672754+00:00",
-      "modification_date": "2025-07-03T23:54:03.672754+00:00", "bootscript": null,
-      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
-      "filesystems": [], "end_of_service": false}}'
-    headers:
-      Content-Length:
-      - "2162"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:03 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d20190a3-a38f-4423-b1c0-c4a16fb89210
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c5bf1369-944b-48eb-a9c8-2aeba6c71f16
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: '{"name":"snp-upbeat-northcutt","volume_id":"f1b7a5e2-6866-4b44-b32b-31f04f396ac0","project":"19a4819b-24bf-4d44-969f-935ef0061b71","volume_type":"l_ssd"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
-    method: POST
-  response:
-    body: '{"snapshot": {"id": "d0672d86-a469-4e2e-82dd-7923d7e22813", "name": "snp-upbeat-northcutt",
-      "volume_type": "l_ssd", "creation_date": "2025-07-03T23:54:03.997474+00:00",
-      "modification_date": "2025-07-03T23:54:03.997474+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
-      "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "size": 15000000000, "state":
-      "available", "base_volume": {"id": "f1b7a5e2-6866-4b44-b32b-31f04f396ac0", "name":
-      "Ubuntu 20.04 Focal Fossa"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}, "task": {"id": "dd9bde21-4415-425e-b69a-10f03d6eae7a", "description":
-      "volume_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
-      "snapshots/d0672d86-a469-4e2e-82dd-7923d7e22813", "started_at": "2025-07-03T23:54:04.201701+00:00",
+      "snapshots/8abcb0ee-f52c-4142-bc1e-45757160cd3f", "started_at": "2025-07-04T14:37:28.109380+00:00",
       "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
     headers:
       Content-Length:
@@ -2344,9 +1485,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:54:04 GMT
+      - Fri, 04 Jul 2025 14:37:28 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2354,7 +1495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8905fe3-78db-48ff-84a1-66594674eabd
+      - 7aae7133-c9b8-4b82-a7c6-166d5aa4ed3f
     status: 201 Created
     code: 201
     duration: ""
@@ -2364,45 +1505,45 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d20190a3-a38f-4423-b1c0-c4a16fb89210
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e27d9b4b-3631-499e-bb62-5b0a3b1beb58
     method: GET
   response:
-    body: '{"server": {"id": "d20190a3-a38f-4423-b1c0-c4a16fb89210", "name": "srv-vigilant-cartwright",
+    body: '{"server": {"id": "e27d9b4b-3631-499e-bb62-5b0a3b1beb58", "name": "srv-pedantic-goodall",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "hostname": "srv-vigilant-cartwright", "image": {"id": "4a4d2994-e7e0-4b29-a760-36235e6ba258",
+      "hostname": "srv-pedantic-goodall", "image": {"id": "4a4d2994-e7e0-4b29-a760-36235e6ba258",
       "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "37000787-865a-4306-8ac4-5a0b2e2fcbbe",
       "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:47:39.547126+00:00",
       "modification_date": "2025-06-25T15:47:39.547126+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "f1b7a5e2-6866-4b44-b32b-31f04f396ac0",
+      "volumes": {"0": {"boot": false, "id": "d068daf9-3c35-4e7c-91b7-f47e9f400ca3",
       "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "export_uri": null,
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "server": {"id": "d20190a3-a38f-4423-b1c0-c4a16fb89210", "name": "srv-vigilant-cartwright"},
-      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:54:03.672754+00:00",
-      "modification_date": "2025-07-03T23:54:03.672754+00:00", "tags": [], "zone":
+      "server": {"id": "e27d9b4b-3631-499e-bb62-5b0a3b1beb58", "name": "srv-pedantic-goodall"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-04T14:37:27.547294+00:00",
+      "modification_date": "2025-07-04T14:37:27.547294+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:b1",
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:35:89",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:54:03.672754+00:00",
-      "modification_date": "2025-07-03T23:54:03.672754+00:00", "bootscript": null,
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-04T14:37:27.547294+00:00",
+      "modification_date": "2025-07-04T14:37:27.547294+00:00", "bootscript": null,
       "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
       "filesystems": [], "end_of_service": false}}'
     headers:
       Content-Length:
-      - "2162"
+      - "2153"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:54:04 GMT
+      - Fri, 04 Jul 2025 14:37:28 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2410,7 +1551,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2aff180-1b41-47a2-89cd-414d69e26067
+      - bacd617f-66c0-47a8-bfac-10381136e1e2
     status: 200 OK
     code: 200
     duration: ""
@@ -2420,7 +1561,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d20190a3-a38f-4423-b1c0-c4a16fb89210
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e27d9b4b-3631-499e-bb62-5b0a3b1beb58
     method: DELETE
   response:
     body: ""
@@ -2430,9 +1571,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:54:04 GMT
+      - Fri, 04 Jul 2025 14:37:28 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2440,7 +1581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d65560cf-995d-4e12-85ec-519d7a3c1359
+      - 648f2dc1-5ac9-441b-b89c-09448ce742b5
     status: 204 No Content
     code: 204
     duration: ""
@@ -2450,7 +1591,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f1b7a5e2-6866-4b44-b32b-31f04f396ac0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d068daf9-3c35-4e7c-91b7-f47e9f400ca3
     method: DELETE
   response:
     body: ""
@@ -2460,9 +1601,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:54:04 GMT
+      - Fri, 04 Jul 2025 14:37:28 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2470,233 +1611,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d82831a-1a20-4f1d-8e1d-f934423e5538
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: '{"name":"vol-loving-mclean","perf_iops":5000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","from_empty":{"size":15000000000},"tags":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
-    method: POST
-  response:
-    body: '{"id":"9f4ac333-112b-440c-a257-658829ef7754","name":"vol-loving-mclean","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:04.700794Z","updated_at":"2025-07-03T23:54:04.700794Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "400"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:04 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 66764e6a-1c41-4a76-a94c-0bf7da9500ab
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9f4ac333-112b-440c-a257-658829ef7754
-    method: GET
-  response:
-    body: '{"id":"9f4ac333-112b-440c-a257-658829ef7754","name":"vol-loving-mclean","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:04.700794Z","updated_at":"2025-07-03T23:54:04.700794Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "400"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:04 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5f2eb5a3-3cdc-4c0a-a56d-214423840f0a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9f4ac333-112b-440c-a257-658829ef7754
-    method: GET
-  response:
-    body: '{"id":"9f4ac333-112b-440c-a257-658829ef7754","name":"vol-loving-mclean","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:04.700794Z","updated_at":"2025-07-03T23:54:04.700794Z","references":[],"parent_snapshot_id":null,"status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "401"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:09 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 059ece41-f257-4825-82a5-a90a14516209
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"volume_id":"9f4ac333-112b-440c-a257-658829ef7754","name":"snp-elegant-bose","project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots
-    method: POST
-  response:
-    body: '{"id":"be0aba55-1a40-406f-8010-cf483a8f6018","name":"snp-elegant-bose","parent_volume":{"id":"9f4ac333-112b-440c-a257-658829ef7754","name":"vol-loving-mclean","type":"sbs_5k","status":"available"},"size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:09.916299Z","updated_at":"2025-07-03T23:54:09.916299Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "432"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:10 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8a49ae22-ff28-451a-92b1-6dd30ff28947
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/be0aba55-1a40-406f-8010-cf483a8f6018
-    method: GET
-  response:
-    body: '{"id":"be0aba55-1a40-406f-8010-cf483a8f6018","name":"snp-elegant-bose","parent_volume":{"id":"9f4ac333-112b-440c-a257-658829ef7754","name":"vol-loving-mclean","type":"sbs_5k","status":"available"},"size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:09.916299Z","updated_at":"2025-07-03T23:54:09.916299Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "432"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:10 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 26225f20-9af8-4a45-b24e-236e989f4c3b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/be0aba55-1a40-406f-8010-cf483a8f6018
-    method: GET
-  response:
-    body: '{"id":"be0aba55-1a40-406f-8010-cf483a8f6018","name":"snp-elegant-bose","parent_volume":{"id":"9f4ac333-112b-440c-a257-658829ef7754","name":"vol-loving-mclean","type":"sbs_5k","status":"available"},"size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:09.916299Z","updated_at":"2025-07-03T23:54:09.916299Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "433"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:15 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b0f0070a-307e-4925-8c8d-27aa7eab9d4a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/9f4ac333-112b-440c-a257-658829ef7754
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 03 Jul 2025 23:54:15 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 04094111-a444-453e-815f-8b441cf793b8
+      - 87291cc5-cd0e-4ea2-9838-604defa97e39
     status: 204 No Content
     code: 204
     duration: ""
@@ -2718,9 +1633,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:54:15 GMT
+      - Fri, 04 Jul 2025 14:37:28 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2728,12 +1643,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ea44361-d9e7-4d22-bd43-83f0906b362b
+      - 1a591601-9359-44f4-ba5d-0027ecbc749f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"srv-priceless-lamarr","commercial_type":"GP1-XS","image":"c5c72a76-0e9b-437b-a6c9-980d7163c152","volumes":{"0":{"name":"empty-root-volume","volume_type":"sbs_volume","base_snapshot":"be0aba55-1a40-406f-8010-cf483a8f6018"},"1":{"boot":true,"name":"boot-on-index-1-local","volume_type":"l_ssd","base_snapshot":"d0672d86-a469-4e2e-82dd-7923d7e22813"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
+    body: '{"name":"srv-inspiring-poincare","commercial_type":"GP1-XS","image":"c5c72a76-0e9b-437b-a6c9-980d7163c152","volumes":{"0":{"name":"local-volume-from-snap","volume_type":"l_ssd","base_snapshot":"8abcb0ee-f52c-4142-bc1e-45757160cd3f"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
     form: {}
     headers:
       Content-Type:
@@ -2743,45 +1658,44 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "e3738cc7-cc88-458b-a3c3-bdb6577c1577", "name": "srv-priceless-lamarr",
+    body: '{"server": {"id": "26424c3b-975b-432f-b6b8-d7cabd9e8f81", "name": "srv-inspiring-poincare",
       "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "hostname": "srv-priceless-lamarr", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
+      "hostname": "srv-inspiring-poincare", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
       "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "c9aa87c7-29a5-4f6c-a4ec-38013b0c12f8",
       "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T12:56:49.762531+00:00",
       "modification_date": "2025-06-25T12:56:49.762531+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "3725e6f2-c7b0-44b0-8306-c76e2fd1e9ca",
-      "zone": "fr-par-1"}, "1": {"boot": true, "id": "c26f0619-02d2-4e47-9125-d2ea307476de",
-      "name": "boot-on-index-1-local", "volume_type": "l_ssd", "export_uri": null,
+      "volumes": {"0": {"boot": false, "id": "edbbca81-3831-414c-80f6-aef63f8ce537",
+      "name": "local-volume-from-snap", "volume_type": "l_ssd", "export_uri": null,
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "server": {"id": "e3738cc7-cc88-458b-a3c3-bdb6577c1577", "name": "srv-priceless-lamarr"},
-      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:54:15.766179+00:00",
-      "modification_date": "2025-07-03T23:54:15.766179+00:00", "tags": [], "zone":
+      "server": {"id": "26424c3b-975b-432f-b6b8-d7cabd9e8f81", "name": "srv-inspiring-poincare"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-04T14:37:28.736017+00:00",
+      "modification_date": "2025-07-04T14:37:28.736017+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:b5",
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:35:8b",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:54:15.766179+00:00",
-      "modification_date": "2025-07-03T23:54:15.766179+00:00", "bootscript": null,
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-04T14:37:28.736017+00:00",
+      "modification_date": "2025-07-04T14:37:28.736017+00:00", "bootscript": null,
       "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
       "filesystems": [], "end_of_service": false}}'
     headers:
       Content-Length:
-      - "2268"
+      - "2159"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:54:16 GMT
+      - Fri, 04 Jul 2025 14:37:28 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3738cc7-cc88-458b-a3c3-bdb6577c1577
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26424c3b-975b-432f-b6b8-d7cabd9e8f81
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2789,7 +1703,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8520533-b9ef-43e5-b242-e772fd954f2e
+      - 8baffaec-b8b9-4286-994d-6a63158e3523
     status: 201 Created
     code: 201
     duration: ""
@@ -2811,9 +1725,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:54:16 GMT
+      - Fri, 04 Jul 2025 14:37:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2821,7 +1735,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63e46f8c-8e69-41d8-a614-6086b6adb2f6
+      - 8fff3a86-e2ae-472e-9fce-508dbbad8807
     status: 200 OK
     code: 200
     duration: ""
@@ -2831,46 +1745,45 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3738cc7-cc88-458b-a3c3-bdb6577c1577
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26424c3b-975b-432f-b6b8-d7cabd9e8f81
     method: GET
   response:
-    body: '{"server": {"id": "e3738cc7-cc88-458b-a3c3-bdb6577c1577", "name": "srv-priceless-lamarr",
+    body: '{"server": {"id": "26424c3b-975b-432f-b6b8-d7cabd9e8f81", "name": "srv-inspiring-poincare",
       "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
       "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "hostname": "srv-priceless-lamarr", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
+      "hostname": "srv-inspiring-poincare", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
       "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "c9aa87c7-29a5-4f6c-a4ec-38013b0c12f8",
       "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T12:56:49.762531+00:00",
       "modification_date": "2025-06-25T12:56:49.762531+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "3725e6f2-c7b0-44b0-8306-c76e2fd1e9ca",
-      "zone": "fr-par-1"}, "1": {"boot": true, "id": "c26f0619-02d2-4e47-9125-d2ea307476de",
-      "name": "boot-on-index-1-local", "volume_type": "l_ssd", "export_uri": null,
+      "volumes": {"0": {"boot": false, "id": "edbbca81-3831-414c-80f6-aef63f8ce537",
+      "name": "local-volume-from-snap", "volume_type": "l_ssd", "export_uri": null,
       "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
-      "server": {"id": "e3738cc7-cc88-458b-a3c3-bdb6577c1577", "name": "srv-priceless-lamarr"},
-      "size": 15000000000, "state": "available", "creation_date": "2025-07-03T23:54:15.766179+00:00",
-      "modification_date": "2025-07-03T23:54:15.766179+00:00", "tags": [], "zone":
+      "server": {"id": "26424c3b-975b-432f-b6b8-d7cabd9e8f81", "name": "srv-inspiring-poincare"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-04T14:37:28.736017+00:00",
+      "modification_date": "2025-07-04T14:37:28.736017+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:08:b5",
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:35:8b",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-03T23:54:15.766179+00:00",
-      "modification_date": "2025-07-03T23:54:15.766179+00:00", "bootscript": null,
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-04T14:37:28.736017+00:00",
+      "modification_date": "2025-07-04T14:37:28.736017+00:00", "bootscript": null,
       "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
       "filesystems": [], "end_of_service": false}}'
     headers:
       Content-Length:
-      - "2268"
+      - "2159"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:54:16 GMT
+      - Fri, 04 Jul 2025 14:37:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2878,7 +1791,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f71059ee-18a3-488f-9519-5691f146b2d2
+      - 106d5af2-0d8b-4960-b995-10b0bbd681c5
     status: 200 OK
     code: 200
     duration: ""
@@ -2888,7 +1801,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3738cc7-cc88-458b-a3c3-bdb6577c1577
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/26424c3b-975b-432f-b6b8-d7cabd9e8f81
     method: DELETE
   response:
     body: ""
@@ -2898,9 +1811,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:54:16 GMT
+      - Fri, 04 Jul 2025 14:37:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2908,7 +1821,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 049ac81c-7117-46f4-886b-87786c23badd
+      - ea113bcd-1764-424f-8f5a-8208d21231d3
     status: 204 No Content
     code: 204
     duration: ""
@@ -2918,21 +1831,19 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/3725e6f2-c7b0-44b0-8306-c76e2fd1e9ca
-    method: GET
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/edbbca81-3831-414c-80f6-aef63f8ce537
+    method: DELETE
   response:
-    body: '{"id":"3725e6f2-c7b0-44b0-8306-c76e2fd1e9ca","name":"empty-root-volume","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:15.879185Z","updated_at":"2025-07-03T23:54:15.879185Z","references":[{"id":"8b226362-58c5-407c-ac98-25d314b6bef9","product_resource_type":"instance_server","product_resource_id":"e3738cc7-cc88-458b-a3c3-bdb6577c1577","created_at":"2025-07-03T23:54:15.879185Z","type":"exclusive","status":"detaching"}],"parent_snapshot_id":"be0aba55-1a40-406f-8010-cf483a8f6018","status":"in_use","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    body: ""
     headers:
-      Content-Length:
-      - "663"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:54:16 GMT
+      - Fri, 04 Jul 2025 14:37:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2940,7 +1851,71 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bcf9af64-abe0-42ec-86f6-7207897287c6
+      - 177fb7c7-b8ef-45bd-8c3f-0eab6025b9ee
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/8abcb0ee-f52c-4142-bc1e-45757160cd3f
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:29 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 93e3eea3-1602-49fc-b2f0-4b77b541db3b
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"name":"vol-busy-saha","perf_iops":5000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","from_empty":{"size":15000000000},"tags":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+    method: POST
+  response:
+    body: '{"id":"e90bb709-efb1-4953-b626-6954e530736f","name":"vol-busy-saha","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:29.549663Z","updated_at":"2025-07-04T14:37:29.549663Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "396"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:29 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a9f4b4ad-b41e-43fd-880f-0e6e26cf6bdc
     status: 200 OK
     code: 200
     duration: ""
@@ -2950,10 +1925,1035 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/3725e6f2-c7b0-44b0-8306-c76e2fd1e9ca
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_noble&order_by=type_asc&type=instance_sbs&zone=fr-par-1
     method: GET
   response:
-    body: '{"id":"3725e6f2-c7b0-44b0-8306-c76e2fd1e9ca","name":"empty-root-volume","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-03T23:54:15.879185Z","updated_at":"2025-07-03T23:54:16.968317Z","references":[],"parent_snapshot_id":"be0aba55-1a40-406f-8010-cf483a8f6018","status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-07-03T23:54:16.968317Z","zone":"fr-par-1"}'
+    body: '{"local_images":[{"id":"95ec2a11-243f-4feb-8efa-155594e2c201","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-48C-192G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-48C-384G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-48C-96G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"label":"ubuntu_noble","type":"instance_sbs"},{"id":"e5758c61-4375-4ce5-b3d5-2f9ffd2b682d","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_noble","type":"instance_sbs"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1185"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:29 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cce17ef6-d9ed-415a-9bbc-e4c7d437f2de
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"srv-wizardly-kirch","commercial_type":"GP1-XS","image":"95ec2a11-243f-4feb-8efa-155594e2c201","volumes":{"0":{"name":"empty-root-volume","size":15000000000,"volume_type":"l_ssd"},"1":{"id":"e90bb709-efb1-4953-b626-6954e530736f","boot":true,"volume_type":"sbs_volume"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+    method: POST
+  response:
+    body: '{"server": {"id": "e858d1ad-77c2-405b-bf75-e8942b6e97ee", "name": "srv-wizardly-kirch",
+      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-wizardly-kirch", "image": {"id": "95ec2a11-243f-4feb-8efa-155594e2c201",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "e9dae602-1f3d-44c3-b377-a6aed7af0e7e", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2025-06-25T12:56:03.466236+00:00", "modification_date": "2025-06-25T12:56:03.466236+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "0eee8cde-903e-4279-a047-3bb5685d221c",
+      "name": "empty-root-volume", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "e858d1ad-77c2-405b-bf75-e8942b6e97ee", "name": "srv-wizardly-kirch"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-04T14:37:29.879305+00:00",
+      "modification_date": "2025-07-04T14:37:29.879305+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": true, "volume_type": "sbs_volume", "id": "e90bb709-efb1-4953-b626-6954e530736f",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:35:8d",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-04T14:37:29.879305+00:00",
+      "modification_date": "2025-07-04T14:37:29.879305+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2230"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:30 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e858d1ad-77c2-405b-bf75-e8942b6e97ee
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2ae4d46f-de13-4962-a0b2-9c4457641b8f
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images/95ec2a11-243f-4feb-8efa-155594e2c201
+    method: GET
+  response:
+    body: '{"id":"95ec2a11-243f-4feb-8efa-155594e2c201","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-48C-192G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-48C-384G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-48C-96G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"label":"ubuntu_noble","type":"instance_sbs"}'
+    headers:
+      Content-Length:
+      - "907"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 837a1055-fa22-4835-bfdd-2feb5e7f7d2a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e858d1ad-77c2-405b-bf75-e8942b6e97ee
+    method: GET
+  response:
+    body: '{"server": {"id": "e858d1ad-77c2-405b-bf75-e8942b6e97ee", "name": "srv-wizardly-kirch",
+      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-wizardly-kirch", "image": {"id": "95ec2a11-243f-4feb-8efa-155594e2c201",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "e9dae602-1f3d-44c3-b377-a6aed7af0e7e", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2025-06-25T12:56:03.466236+00:00", "modification_date": "2025-06-25T12:56:03.466236+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "id": "0eee8cde-903e-4279-a047-3bb5685d221c",
+      "name": "empty-root-volume", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "e858d1ad-77c2-405b-bf75-e8942b6e97ee", "name": "srv-wizardly-kirch"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-04T14:37:29.879305+00:00",
+      "modification_date": "2025-07-04T14:37:29.879305+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": true, "volume_type": "sbs_volume", "id": "e90bb709-efb1-4953-b626-6954e530736f",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:35:8d",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-04T14:37:29.879305+00:00",
+      "modification_date": "2025-07-04T14:37:29.879305+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2230"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b14908c3-800d-44d5-8505-074e7b6d1260
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e858d1ad-77c2-405b-bf75-e8942b6e97ee
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3d15248a-2a8e-4353-b84e-6f2014ba05e4
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0eee8cde-903e-4279-a047-3bb5685d221c
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:31 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 11ae050a-e672-4287-83ab-6216285f868e
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e90bb709-efb1-4953-b626-6954e530736f
+    method: GET
+  response:
+    body: '{"id":"e90bb709-efb1-4953-b626-6954e530736f","name":"vol-busy-saha","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:29.549663Z","updated_at":"2025-07-04T14:37:30.989108Z","references":[],"parent_snapshot_id":null,"status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-07-04T14:37:30.989108Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "422"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:31 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 61f8e04b-9ed9-47e1-8494-6859ed2619a5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e90bb709-efb1-4953-b626-6954e530736f
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:31 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 48bc3dd3-2a86-4a2c-9796-c859d00fbe89
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=type_asc&type=instance_local&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"4a4d2994-e7e0-4b29-a760-36235e6ba258","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","STARDUST1-S","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB"],"label":"ubuntu_focal","type":"instance_local"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "397"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:31 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f6e68d77-3b84-4fd6-9e83-e42f761530b9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"srv-priceless-northcutt","commercial_type":"DEV1-S","image":"4a4d2994-e7e0-4b29-a760-36235e6ba258","volumes":{"0":{"size":15000000000,"volume_type":"l_ssd"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+    method: POST
+  response:
+    body: '{"server": {"id": "18857cae-adfa-44e5-acf8-d09a63940573", "name": "srv-priceless-northcutt",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-priceless-northcutt", "image": {"id": "4a4d2994-e7e0-4b29-a760-36235e6ba258",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "37000787-865a-4306-8ac4-5a0b2e2fcbbe",
+      "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:47:39.547126+00:00",
+      "modification_date": "2025-06-25T15:47:39.547126+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "3b74b0a0-2a59-4033-95e4-aafe1e20fc8b",
+      "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "18857cae-adfa-44e5-acf8-d09a63940573", "name": "srv-priceless-northcutt"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-04T14:37:31.401562+00:00",
+      "modification_date": "2025-07-04T14:37:31.401562+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:35:8f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-04T14:37:31.401562+00:00",
+      "modification_date": "2025-07-04T14:37:31.401562+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2162"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:31 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/18857cae-adfa-44e5-acf8-d09a63940573
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4e7a7b14-c2e6-460b-9e52-763fb01f8119
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"name":"snp-crazy-mahavira","volume_id":"3b74b0a0-2a59-4033-95e4-aafe1e20fc8b","project":"19a4819b-24bf-4d44-969f-935ef0061b71","volume_type":"l_ssd"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
+    method: POST
+  response:
+    body: '{"snapshot": {"id": "ff7c08f0-8a37-48a2-99ae-345371dd564c", "name": "snp-crazy-mahavira",
+      "volume_type": "l_ssd", "creation_date": "2025-07-04T14:37:31.678404+00:00",
+      "modification_date": "2025-07-04T14:37:31.678404+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "19a4819b-24bf-4d44-969f-935ef0061b71", "size": 15000000000, "state":
+      "available", "base_volume": {"id": "3b74b0a0-2a59-4033-95e4-aafe1e20fc8b", "name":
+      "Ubuntu 20.04 Focal Fossa"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}, "task": {"id": "d2d2b227-5f92-4d6c-90ad-2790de6c61e1", "description":
+      "volume_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
+      "snapshots/ff7c08f0-8a37-48a2-99ae-345371dd564c", "started_at": "2025-07-04T14:37:31.933465+00:00",
+      "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "839"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:31 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dd03ae67-1db5-4f06-aff0-4808c07d56b1
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/18857cae-adfa-44e5-acf8-d09a63940573
+    method: GET
+  response:
+    body: '{"server": {"id": "18857cae-adfa-44e5-acf8-d09a63940573", "name": "srv-priceless-northcutt",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-priceless-northcutt", "image": {"id": "4a4d2994-e7e0-4b29-a760-36235e6ba258",
+      "name": "Ubuntu 20.04 Focal Fossa", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "37000787-865a-4306-8ac4-5a0b2e2fcbbe",
+      "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:47:39.547126+00:00",
+      "modification_date": "2025-06-25T15:47:39.547126+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "3b74b0a0-2a59-4033-95e4-aafe1e20fc8b",
+      "name": "Ubuntu 20.04 Focal Fossa", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "18857cae-adfa-44e5-acf8-d09a63940573", "name": "srv-priceless-northcutt"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-04T14:37:31.401562+00:00",
+      "modification_date": "2025-07-04T14:37:31.401562+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:35:8f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-04T14:37:31.401562+00:00",
+      "modification_date": "2025-07-04T14:37:31.401562+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2162"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:32 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9c91e618-d2ac-48b9-aa48-aa4606556f42
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/18857cae-adfa-44e5-acf8-d09a63940573
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:32 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 69750ec5-b0c6-4838-b276-ba073209ec52
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3b74b0a0-2a59-4033-95e4-aafe1e20fc8b
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:32 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - da0f12cb-1a34-451c-b7e2-ded2b046c288
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"name":"vol-peaceful-meitner","perf_iops":5000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","from_empty":{"size":15000000000},"tags":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+    method: POST
+  response:
+    body: '{"id":"c44309a9-551e-4197-801e-2229b6acd03f","name":"vol-peaceful-meitner","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:32.344879Z","updated_at":"2025-07-04T14:37:32.344879Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "403"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:32 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4e345eb3-7dd2-4b1f-9865-82e4eac87bd0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/c44309a9-551e-4197-801e-2229b6acd03f
+    method: GET
+  response:
+    body: '{"id":"c44309a9-551e-4197-801e-2229b6acd03f","name":"vol-peaceful-meitner","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:32.344879Z","updated_at":"2025-07-04T14:37:32.344879Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "403"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:32 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f448e20e-ac8d-4b09-982f-27e6fd60ff09
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/c44309a9-551e-4197-801e-2229b6acd03f
+    method: GET
+  response:
+    body: '{"id":"c44309a9-551e-4197-801e-2229b6acd03f","name":"vol-peaceful-meitner","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:32.344879Z","updated_at":"2025-07-04T14:37:32.344879Z","references":[],"parent_snapshot_id":null,"status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "404"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:37 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dbff7ae8-2d9d-4cb5-89cc-6c21a6178ee5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"volume_id":"c44309a9-551e-4197-801e-2229b6acd03f","name":"snp-serene-lovelace","project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","tags":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots
+    method: POST
+  response:
+    body: '{"id":"e95a10ec-b410-4001-87e4-2b6dfd207681","name":"snp-serene-lovelace","parent_volume":{"id":"c44309a9-551e-4197-801e-2229b6acd03f","name":"vol-peaceful-meitner","type":"sbs_5k","status":"available"},"size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:37.592092Z","updated_at":"2025-07-04T14:37:37.592092Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "438"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:37 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 42021525-0ebc-4433-bd36-77abbcc65b3e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e95a10ec-b410-4001-87e4-2b6dfd207681
+    method: GET
+  response:
+    body: '{"id":"e95a10ec-b410-4001-87e4-2b6dfd207681","name":"snp-serene-lovelace","parent_volume":{"id":"c44309a9-551e-4197-801e-2229b6acd03f","name":"vol-peaceful-meitner","type":"sbs_5k","status":"available"},"size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:37.592092Z","updated_at":"2025-07-04T14:37:37.592092Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "438"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:37 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9aa7abff-6984-4572-9253-5ebe4349580e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e95a10ec-b410-4001-87e4-2b6dfd207681
+    method: GET
+  response:
+    body: '{"id":"e95a10ec-b410-4001-87e4-2b6dfd207681","name":"snp-serene-lovelace","parent_volume":{"id":"c44309a9-551e-4197-801e-2229b6acd03f","name":"vol-peaceful-meitner","type":"sbs_5k","status":"available"},"size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:37.592092Z","updated_at":"2025-07-04T14:37:37.592092Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "439"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:43 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - df62342c-833c-40be-a0d7-39a275e644e7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/c44309a9-551e-4197-801e-2229b6acd03f
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:43 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4e69f744-3cf2-478d-a8c2-fdb11e3876e8
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_noble&order_by=type_asc&type=instance_local&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"c5c72a76-0e9b-437b-a6c9-980d7163c152","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","STARDUST1-S","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB"],"label":"ubuntu_noble","type":"instance_local"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "397"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:43 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c76b3300-28f5-4662-ae70-cb7db76e346b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"srv-sharp-bhabha","commercial_type":"GP1-XS","image":"c5c72a76-0e9b-437b-a6c9-980d7163c152","volumes":{"0":{"name":"empty-root-volume","volume_type":"sbs_volume","base_snapshot":"e95a10ec-b410-4001-87e4-2b6dfd207681"},"1":{"boot":true,"name":"boot-on-index-1-local","volume_type":"l_ssd","base_snapshot":"ff7c08f0-8a37-48a2-99ae-345371dd564c"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+    method: POST
+  response:
+    body: '{"server": {"id": "34347d0b-6a04-4a4c-bd84-9875f535d83e", "name": "srv-sharp-bhabha",
+      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-sharp-bhabha", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "c9aa87c7-29a5-4f6c-a4ec-38013b0c12f8",
+      "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T12:56:49.762531+00:00",
+      "modification_date": "2025-06-25T12:56:49.762531+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "ec8785e2-fbab-4ae0-802b-536524336c37",
+      "zone": "fr-par-1"}, "1": {"boot": true, "id": "5c25a6b4-a27d-42ed-be73-84ea09cd5643",
+      "name": "boot-on-index-1-local", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "34347d0b-6a04-4a4c-bd84-9875f535d83e", "name": "srv-sharp-bhabha"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-04T14:37:43.565195+00:00",
+      "modification_date": "2025-07-04T14:37:43.565195+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:35:93",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-04T14:37:43.565195+00:00",
+      "modification_date": "2025-07-04T14:37:43.565195+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:44 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/34347d0b-6a04-4a4c-bd84-9875f535d83e
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8991a850-f7a5-4a95-9120-254cf2bfd7d3
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images/c5c72a76-0e9b-437b-a6c9-980d7163c152
+    method: GET
+  response:
+    body: '{"id":"c5c72a76-0e9b-437b-a6c9-980d7163c152","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","STARDUST1-S","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB"],"label":"ubuntu_noble","type":"instance_local"}'
+    headers:
+      Content-Length:
+      - "362"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3c42476a-1aa8-484f-9d6f-085508d6b206
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/34347d0b-6a04-4a4c-bd84-9875f535d83e
+    method: GET
+  response:
+    body: '{"server": {"id": "34347d0b-6a04-4a4c-bd84-9875f535d83e", "name": "srv-sharp-bhabha",
+      "arch": "x86_64", "commercial_type": "GP1-XS", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-sharp-bhabha", "image": {"id": "c5c72a76-0e9b-437b-a6c9-980d7163c152",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "c9aa87c7-29a5-4f6c-a4ec-38013b0c12f8",
+      "name": "Ubuntu 24.04 Noble Numbat", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T12:56:49.762531+00:00",
+      "modification_date": "2025-06-25T12:56:49.762531+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "volume_type": "sbs_volume", "id": "ec8785e2-fbab-4ae0-802b-536524336c37",
+      "zone": "fr-par-1"}, "1": {"boot": true, "id": "5c25a6b4-a27d-42ed-be73-84ea09cd5643",
+      "name": "boot-on-index-1-local", "volume_type": "l_ssd", "export_uri": null,
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "server": {"id": "34347d0b-6a04-4a4c-bd84-9875f535d83e", "name": "srv-sharp-bhabha"},
+      "size": 15000000000, "state": "available", "creation_date": "2025-07-04T14:37:43.565195+00:00",
+      "modification_date": "2025-07-04T14:37:43.565195+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:bb:35:93",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-04T14:37:43.565195+00:00",
+      "modification_date": "2025-07-04T14:37:43.565195+00:00", "bootscript": null,
+      "security_group": {"id": "2d7d322d-5ca8-4eea-9fdf-3885ed983d91", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ed6d984c-152c-45ea-9bfa-3575d4abdf56
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/34347d0b-6a04-4a4c-bd84-9875f535d83e
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2c197a7f-8e35-4b95-b903-8ea728f77d38
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ec8785e2-fbab-4ae0-802b-536524336c37
+    method: GET
+  response:
+    body: '{"id":"ec8785e2-fbab-4ae0-802b-536524336c37","name":"empty-root-volume","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:43.688340Z","updated_at":"2025-07-04T14:37:43.688340Z","references":[{"id":"b6e6d28c-e056-4cd8-a6f3-1c3455fa6518","product_resource_type":"instance_server","product_resource_id":"34347d0b-6a04-4a4c-bd84-9875f535d83e","created_at":"2025-07-04T14:37:43.688340Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":"e95a10ec-b410-4001-87e4-2b6dfd207681","status":"in_use","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "662"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 95631c4d-dc9d-4956-87f3-263fddb14bba
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ec8785e2-fbab-4ae0-802b-536524336c37
+    method: GET
+  response:
+    body: '{"id":"ec8785e2-fbab-4ae0-802b-536524336c37","name":"empty-root-volume","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:43.688340Z","updated_at":"2025-07-04T14:37:44.584139Z","references":[],"parent_snapshot_id":"e95a10ec-b410-4001-87e4-2b6dfd207681","status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-07-04T14:37:44.584139Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "460"
@@ -2962,9 +2962,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:54:22 GMT
+      - Fri, 04 Jul 2025 14:37:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2972,7 +2972,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b200fd4-0880-40c5-81a0-9d20553b8e72
+      - 5156c7c1-b3da-4196-b4b9-56edac32dc82
     status: 200 OK
     code: 200
     duration: ""
@@ -2982,7 +2982,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/3725e6f2-c7b0-44b0-8306-c76e2fd1e9ca
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ec8785e2-fbab-4ae0-802b-536524336c37
     method: DELETE
   response:
     body: ""
@@ -2992,9 +2992,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:54:22 GMT
+      - Fri, 04 Jul 2025 14:37:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3002,7 +3002,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa144c1f-4677-4305-825a-14c549187bed
+      - ceaed113-2397-4e48-a784-d01186d90841
     status: 204 No Content
     code: 204
     duration: ""
@@ -3012,7 +3012,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/c26f0619-02d2-4e47-9125-d2ea307476de
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5c25a6b4-a27d-42ed-be73-84ea09cd5643
     method: DELETE
   response:
     body: ""
@@ -3022,9 +3022,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:54:22 GMT
+      - Fri, 04 Jul 2025 14:37:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3032,7 +3032,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68ee923c-ebec-422b-bc52-bdc36faae782
+      - 57f144a5-1c6a-4a31-8db6-8a1673ef732f
     status: 204 No Content
     code: 204
     duration: ""
@@ -3042,7 +3042,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d0672d86-a469-4e2e-82dd-7923d7e22813
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/ff7c08f0-8a37-48a2-99ae-345371dd564c
     method: DELETE
   response:
     body: ""
@@ -3052,9 +3052,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:54:22 GMT
+      - Fri, 04 Jul 2025 14:37:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3062,7 +3062,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62609ba4-21e7-416b-8f40-c90401f4964b
+      - c7777cb1-2d13-4284-9037-193169194cc0
     status: 204 No Content
     code: 204
     duration: ""
@@ -3072,11 +3072,11 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/be0aba55-1a40-406f-8010-cf483a8f6018
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/e95a10ec-b410-4001-87e4-2b6dfd207681
     method: DELETE
   response:
     body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_snapshot",
-      "resource_id": "be0aba55-1a40-406f-8010-cf483a8f6018"}'
+      "resource_id": "e95a10ec-b410-4001-87e4-2b6dfd207681"}'
     headers:
       Content-Length:
       - "145"
@@ -3085,9 +3085,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:54:22 GMT
+      - Fri, 04 Jul 2025 14:37:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3095,7 +3095,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36274590-1a7e-472e-af13-ec7daaaa923c
+      - 4c3e69ca-a33a-4607-8c88-3fa9073d003e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3105,7 +3105,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/be0aba55-1a40-406f-8010-cf483a8f6018
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/e95a10ec-b410-4001-87e4-2b6dfd207681
     method: DELETE
   response:
     body: ""
@@ -3115,9 +3115,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 03 Jul 2025 23:54:22 GMT
+      - Fri, 04 Jul 2025 14:37:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3125,7 +3125,305 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa4e687a-9fe0-4d6e-92e7-5d099b778503
+      - 3a2adbb0-e96e-46ba-be2c-10e859e3c148
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_noble&order_by=type_asc&type=instance_sbs&zone=fr-par-2
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"b27fefc9-fdfc-4690-ad6f-dc580b328d6b","arch":"x86_64","zone":"fr-par-2","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-48C-192G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-48C-384G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-48C-96G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"label":"ubuntu_noble","type":"instance_sbs"},{"id":"fd801824-64e7-4aed-89d6-4f4b5638de47","arch":"arm64","zone":"fr-par-2","compatible_commercial_types":["COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_noble","type":"instance_sbs"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1060"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:50 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d5293759-3400-4554-ad44-24cad1189038
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"srv-suspicious-boyd","commercial_type":"COPARM1-2C-8G","image":"fd801824-64e7-4aed-89d6-4f4b5638de47","volumes":{"0":{"size":15000000000,"volume_type":"sbs_volume"}},"project":"19a4819b-24bf-4d44-969f-935ef0061b71"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers
+    method: POST
+  response:
+    body: '{"server": {"id": "46847d1f-421f-4549-8bde-ef66eecdb063", "name": "srv-suspicious-boyd",
+      "arch": "arm64", "commercial_type": "COPARM1-2C-8G", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-suspicious-boyd", "image": {"id": "fd801824-64e7-4aed-89d6-4f4b5638de47",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "f552e38a-e61e-4206-a6d5-a5e929d71a58", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "arm64", "creation_date":
+      "2025-06-25T12:56:32.484924+00:00", "modification_date": "2025-06-25T12:56:32.484924+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-2"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "97d1e9ea-af93-45bb-801d-0113a15d9f36", "zone": "fr-par-2"}}, "tags":
+      [], "state": "stopped", "protected": false, "state_detail": "", "public_ip":
+      null, "public_ips": [], "mac_address": "de:00:00:7e:40:85", "routed_ip_enabled":
+      true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6":
+      false, "private_ip": null, "creation_date": "2025-07-04T14:37:50.232697+00:00",
+      "modification_date": "2025-07-04T14:37:50.232697+00:00", "bootscript": null,
+      "security_group": {"id": "570c2ce0-3e5f-45e4-850b-7f0e0498e6fd", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-2",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "1717"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:50 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/46847d1f-421f-4549-8bde-ef66eecdb063
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c6790e5c-ca22-4d76-ab6e-0b15f45d3ec6
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/marketplace/v2/local-images/fd801824-64e7-4aed-89d6-4f4b5638de47
+    method: GET
+  response:
+    body: '{"id":"fd801824-64e7-4aed-89d6-4f4b5638de47","arch":"arm64","zone":"fr-par-2","compatible_commercial_types":["COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_noble","type":"instance_sbs"}'
+    headers:
+      Content-Length:
+      - "242"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:50 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0e0154d5-c4e2-4e55-bebe-cc4d9fdb1ea7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/46847d1f-421f-4549-8bde-ef66eecdb063
+    method: GET
+  response:
+    body: '{"server": {"id": "46847d1f-421f-4549-8bde-ef66eecdb063", "name": "srv-suspicious-boyd",
+      "arch": "arm64", "commercial_type": "COPARM1-2C-8G", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "19a4819b-24bf-4d44-969f-935ef0061b71",
+      "hostname": "srv-suspicious-boyd", "image": {"id": "fd801824-64e7-4aed-89d6-4f4b5638de47",
+      "name": "Ubuntu 24.04 Noble Numbat", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "f552e38a-e61e-4206-a6d5-a5e929d71a58", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "arm64", "creation_date":
+      "2025-06-25T12:56:32.484924+00:00", "modification_date": "2025-06-25T12:56:32.484924+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-2"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "97d1e9ea-af93-45bb-801d-0113a15d9f36", "zone": "fr-par-2"}}, "tags":
+      [], "state": "stopped", "protected": false, "state_detail": "", "public_ip":
+      null, "public_ips": [], "mac_address": "de:00:00:7e:40:85", "routed_ip_enabled":
+      true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6":
+      false, "private_ip": null, "creation_date": "2025-07-04T14:37:50.232697+00:00",
+      "modification_date": "2025-07-04T14:37:50.232697+00:00", "bootscript": null,
+      "security_group": {"id": "570c2ce0-3e5f-45e4-850b-7f0e0498e6fd", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-2",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "1717"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:50 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 69f9e150-1967-446a-9316-df0761cfb6e3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/46847d1f-421f-4549-8bde-ef66eecdb063
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d468ee73-0670-42c3-8d5e-88ad239f5b17
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/97d1e9ea-af93-45bb-801d-0113a15d9f36
+    method: GET
+  response:
+    body: '{"id":"97d1e9ea-af93-45bb-801d-0113a15d9f36","name":"Ubuntu 24.04 Noble
+      Numbat_sbs_volume_0","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:50.356060Z","updated_at":"2025-07-04T14:37:50.356060Z","references":[{"id":"1ced18c8-caef-47ec-aa6d-8bf4156fb487","product_resource_type":"instance_server","product_resource_id":"46847d1f-421f-4549-8bde-ef66eecdb063","created_at":"2025-07-04T14:37:50.356060Z","type":"exclusive","status":"detaching"}],"parent_snapshot_id":"f552e38a-e61e-4206-a6d5-a5e929d71a58","status":"in_use","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-2"}'
+    headers:
+      Content-Length:
+      - "684"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2fe49bea-5e84-4bee-add1-f6d11b5efb38
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/97d1e9ea-af93-45bb-801d-0113a15d9f36
+    method: GET
+  response:
+    body: '{"id":"97d1e9ea-af93-45bb-801d-0113a15d9f36","name":"Ubuntu 24.04 Noble
+      Numbat_sbs_volume_0","type":"sbs_5k","size":15000000000,"project_id":"19a4819b-24bf-4d44-969f-935ef0061b71","created_at":"2025-07-04T14:37:50.356060Z","updated_at":"2025-07-04T14:37:51.201985Z","references":[],"parent_snapshot_id":"f552e38a-e61e-4206-a6d5-a5e929d71a58","status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":"2025-07-04T14:37:51.201985Z","zone":"fr-par-2"}'
+    headers:
+      Content-Length:
+      - "481"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:56 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ae2a75e9-d94a-4eb1-b070-071378d1dbb6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64)
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-2/volumes/97d1e9ea-af93-45bb-801d-0113a15d9f36
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 04 Jul 2025 14:37:56 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ec8d00be-d9f1-4964-b66f-8444054d30c3
     status: 204 No Content
     code: 204
     duration: ""


### PR DESCRIPTION
This PR fixes the image label resolution. By first determining the type of volume on which the instance will boot, we ensure that the image fetched from the marketplace is compatible with the volume.

Closes #2603 