### PR TITLE
feat(client): add an interface to set insecure mode on alt transport

### DIFF
--- a/scw/client.go
+++ b/scw/client.go
@@ -556,6 +556,15 @@ func setInsecureMode(c httpClient) {
 		logger.Warningf("client: cannot use insecure mode with HTTP client of type %T", c)
 		return
 	}
+
+	altTransport, ok := standardHTTPClient.Transport.(interface {
+		SetInsecureTransport()
+	})
+	if ok {
+		altTransport.SetInsecureTransport()
+		return
+	}
+
 	transportClient, ok := standardHTTPClient.Transport.(*http.Transport)
 	if !ok {
 		logger.Warningf("client: cannot use insecure mode with Transport client of type %T", standardHTTPClient.Transport)


### PR DESCRIPTION
This PR adds the possibility to apply the insecure mode on any transport that implement a method `SetInsecureTransport()`

Context: the insecure mode does not work with the CLI because it uses a custom transport client https://github.com/scaleway/scaleway-cli/blob/master/core/bootstrap.go#L151


