### PR TITLE
feat(vpc): add retry function when deleting private networks

### DIFF
--- a/api/vpc/v2/vpc_utils.go
+++ b/api/vpc/v2/vpc_utils.go
@@ -1,0 +1,26 @@
+package vpc
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+func (s *API) TryDeletingPrivateNetwork(req *DeletePrivateNetworkRequest, retriesLeft int, opts ...scw.RequestOption) (*PrivateNetwork, error) {
+	err := s.DeletePrivateNetwork(&DeletePrivateNetworkRequest{
+		PrivateNetworkID: req.PrivateNetworkID,
+		Region:           req.Region,
+	}, opts...)
+
+	var respErr *scw.ResponseError
+	if errors.As(err, &respErr) && respErr.StatusCode == http.StatusInternalServerError {
+		time.Sleep(5 * time.Second)
+		if retriesLeft > 0 {
+			return s.TryDeletingPrivateNetwork(req, retriesLeft-1, opts...)
+		}
+	}
+
+	return nil, err
+}


### PR DESCRIPTION
A lot of tests involving Private Networks are currently failing because of the same error (code 500) that occurs when attempting to delete a PN which state is still transient. 

The VPC API does not disclose the state of the resource, so we can't implement a proper waiter function, but we should at least have a function that retries a few times to delete the resource as long as the error code is 500. 

We could then call this function both in Terraform and in the CLI to fix a good proportion of the nightly tests.