### PR TITLE
feat(sweepers): allow sweepers to be scoped to the default project id

### DIFF
--- a/api/baremetal/v1/sweepers/sweepers.go
+++ b/api/baremetal/v1/sweepers/sweepers.go
@@ -7,10 +7,18 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 
-func SweepServers(scwClient *scw.Client, zone scw.Zone) error {
+func SweepServers(scwClient *scw.Client, zone scw.Zone, projectScoped bool) error {
 	baremetalAPI := baremetal.NewAPI(scwClient)
+	defaultProjectID, exists := scwClient.GetDefaultProjectID()
+	var projectID *string = nil
+	if projectScoped && (!exists || (defaultProjectID == "")) {
+		return fmt.Errorf("failed to get the default project id for a project scoped sweep")
+	}
+	if projectScoped {
+		projectID = &defaultProjectID
+	}
 
-	listServers, err := baremetalAPI.ListServers(&baremetal.ListServersRequest{Zone: zone}, scw.WithAllPages())
+	listServers, err := baremetalAPI.ListServers(&baremetal.ListServersRequest{Zone: zone, ProjectID: projectID}, scw.WithAllPages())
 	if err != nil {
 		return err
 	}
@@ -28,9 +36,9 @@ func SweepServers(scwClient *scw.Client, zone scw.Zone) error {
 	return nil
 }
 
-func SweepAllLocalities(scwClient *scw.Client) error {
+func SweepAllLocalities(scwClient *scw.Client, projectScoped bool) error {
 	for _, zone := range (&baremetal.API{}).Zones() {
-		err := SweepServers(scwClient, zone)
+		err := SweepServers(scwClient, zone, projectScoped)
 		if err != nil {
 			return err
 		}

--- a/api/cockpit/v1/sweepers/sweepers.go
+++ b/api/cockpit/v1/sweepers/sweepers.go
@@ -9,22 +9,18 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 
-func SweepToken(scwClient *scw.Client) error {
+func SweepToken(scwClient *scw.Client, region scw.Region, projectScoped bool) error {
 	accountAPI := accountSDK.NewProjectAPI(scwClient)
 	cockpitAPI := cockpit.NewRegionalAPI(scwClient)
 
-	listProjects, err := accountAPI.ListProjects(&accountSDK.ProjectAPIListProjectsRequest{}, scw.WithAllPages())
-	if err != nil {
-		return fmt.Errorf("failed to list projects: %w", err)
+	defaultProjectID, exists := scwClient.GetDefaultProjectID()
+	if projectScoped && (!exists || (defaultProjectID == "")) {
+		return fmt.Errorf("failed to get the default project id for a project scoped sweep")
 	}
-
-	for _, project := range listProjects.Projects {
-		if !strings.HasPrefix(project.Name, "tf_tests") {
-			continue
-		}
-
+	if projectScoped {
 		listTokens, err := cockpitAPI.ListTokens(&cockpit.RegionalAPIListTokensRequest{
-			ProjectID: project.ID,
+			ProjectID: defaultProjectID,
+			Region:    region,
 		}, scw.WithAllPages())
 		if err != nil {
 			return fmt.Errorf("failed to list tokens: %w", err)
@@ -38,28 +34,52 @@ func SweepToken(scwClient *scw.Client) error {
 				return fmt.Errorf("failed to delete token: %w", err)
 			}
 		}
+	} else {
+		listProjects, err := accountAPI.ListProjects(&accountSDK.ProjectAPIListProjectsRequest{}, scw.WithAllPages())
+		if err != nil {
+			return fmt.Errorf("failed to list projects: %w", err)
+		}
+
+		for _, project := range listProjects.Projects {
+			if !strings.HasPrefix(project.Name, "tf_tests") {
+				continue
+			}
+
+			listTokens, err := cockpitAPI.ListTokens(&cockpit.RegionalAPIListTokensRequest{
+				ProjectID: project.ID,
+				Region:    region,
+			}, scw.WithAllPages())
+			if err != nil {
+				return fmt.Errorf("failed to list tokens: %w", err)
+			}
+
+			for _, token := range listTokens.Tokens {
+				err = cockpitAPI.DeleteToken(&cockpit.RegionalAPIDeleteTokenRequest{
+					TokenID: token.ID,
+				})
+				if err != nil {
+					return fmt.Errorf("failed to delete token: %w", err)
+				}
+			}
+		}
 	}
 
 	return nil
 }
 
-func SweepGrafanaUser(scwClient *scw.Client) error {
+func SweepGrafanaUser(scwClient *scw.Client, projectScoped bool) error {
 	accountAPI := accountSDK.NewProjectAPI(scwClient)
 	cockpitAPI := cockpit.NewGlobalAPI(scwClient)
 
-	listProjects, err := accountAPI.ListProjects(&accountSDK.ProjectAPIListProjectsRequest{}, scw.WithAllPages())
-	if err != nil {
-		return fmt.Errorf("failed to list projects: %w", err)
+	defaultProjectID, exists := scwClient.GetDefaultProjectID()
+	if projectScoped && (!exists || (defaultProjectID == "")) {
+		return fmt.Errorf("failed to get the default project id for a project scoped sweep")
 	}
 
-	for _, project := range listProjects.Projects {
-		if !strings.HasPrefix(project.Name, "tf_tests") {
-			continue
-		}
-
+	if projectScoped {
 		//nolint:staticcheck // ListGrafanaUsers is deprecated but still required for sweeper functionality
 		listGrafanaUsers, err := cockpitAPI.ListGrafanaUsers(&cockpit.GlobalAPIListGrafanaUsersRequest{
-			ProjectID: project.ID,
+			ProjectID: defaultProjectID,
 		}, scw.WithAllPages())
 		if err != nil {
 			return fmt.Errorf("failed to list grafana users: %w", err)
@@ -68,47 +88,40 @@ func SweepGrafanaUser(scwClient *scw.Client) error {
 		for _, grafanaUser := range listGrafanaUsers.GrafanaUsers {
 			//nolint:staticcheck // DeleteGrafanaUser is deprecated but still required for sweeper functionality
 			err = cockpitAPI.DeleteGrafanaUser(&cockpit.GlobalAPIDeleteGrafanaUserRequest{
-				ProjectID:     project.ID,
+				ProjectID:     defaultProjectID,
 				GrafanaUserID: grafanaUser.ID,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to delete grafana user: %w", err)
 			}
 		}
-	}
-
-	return nil
-}
-
-func SweepSource(scwClient *scw.Client, region scw.Region) error {
-	accountAPI := accountSDK.NewProjectAPI(scwClient)
-	cockpitAPI := cockpit.NewRegionalAPI(scwClient)
-
-	listProjects, err := accountAPI.ListProjects(&accountSDK.ProjectAPIListProjectsRequest{}, scw.WithAllPages())
-	if err != nil {
-		return fmt.Errorf("failed to list projects: %w", err)
-	}
-
-	for _, project := range listProjects.Projects {
-		if !strings.HasPrefix(project.Name, "tf_tests") {
-			continue
-		}
-
-		listDatasources, err := cockpitAPI.ListDataSources(&cockpit.RegionalAPIListDataSourcesRequest{
-			ProjectID: project.ID,
-			Region:    region,
-		}, scw.WithAllPages())
+	} else {
+		listProjects, err := accountAPI.ListProjects(&accountSDK.ProjectAPIListProjectsRequest{}, scw.WithAllPages())
 		if err != nil {
-			return fmt.Errorf("failed to list sources: %w", err)
+			return fmt.Errorf("failed to list projects: %w", err)
 		}
+		for _, project := range listProjects.Projects {
+			if !strings.HasPrefix(project.Name, "tf_tests") {
+				continue
+			}
 
-		for _, datsource := range listDatasources.DataSources {
-			err = cockpitAPI.DeleteDataSource(&cockpit.RegionalAPIDeleteDataSourceRequest{
-				DataSourceID: datsource.ID,
-				Region:       region,
-			})
+			//nolint:staticcheck // DeleteGrafanaUser is deprecated but still required for sweeper functionality
+			listGrafanaUsers, err := cockpitAPI.ListGrafanaUsers(&cockpit.GlobalAPIListGrafanaUsersRequest{
+				ProjectID: project.ID,
+			}, scw.WithAllPages())
 			if err != nil {
-				return fmt.Errorf("failed to delete cockpit source: %w", err)
+				return fmt.Errorf("failed to list grafana users: %w", err)
+			}
+
+			for _, grafanaUser := range listGrafanaUsers.GrafanaUsers {
+				//nolint:staticcheck // DeleteGrafanaUser is deprecated but still required for sweeper functionality
+				err = cockpitAPI.DeleteGrafanaUser(&cockpit.GlobalAPIDeleteGrafanaUserRequest{
+					ProjectID:     project.ID,
+					GrafanaUserID: grafanaUser.ID,
+				})
+				if err != nil {
+					return fmt.Errorf("failed to delete grafana user: %w", err)
+				}
 			}
 		}
 	}
@@ -116,15 +129,79 @@ func SweepSource(scwClient *scw.Client, region scw.Region) error {
 	return nil
 }
 
-func SweepAllLocalities(scwClient *scw.Client) error {
-	if err := SweepToken(scwClient); err != nil {
-		return err
+func SweepSource(scwClient *scw.Client, region scw.Region, projectScoped bool) error {
+	accountAPI := accountSDK.NewProjectAPI(scwClient)
+	cockpitAPI := cockpit.NewRegionalAPI(scwClient)
+	defaultProjectID, exists := scwClient.GetDefaultProjectID()
+	if projectScoped && (!exists || (defaultProjectID == "")) {
+		return fmt.Errorf("failed to get the default project id for a project scoped sweep")
 	}
-	if err := SweepGrafanaUser(scwClient); err != nil {
+	if projectScoped {
+		listDatasources, err := cockpitAPI.ListDataSources(&cockpit.RegionalAPIListDataSourcesRequest{
+			ProjectID: defaultProjectID,
+			Region:    region,
+		}, scw.WithAllPages())
+		if err != nil {
+			return fmt.Errorf("failed to list sources: %w", err)
+		}
+
+		for _, datasource := range listDatasources.DataSources {
+			if datasource.Origin == cockpit.DataSourceOriginScaleway {
+				continue
+			}
+			err = cockpitAPI.DeleteDataSource(&cockpit.RegionalAPIDeleteDataSourceRequest{
+				DataSourceID: datasource.ID,
+				Region:       region,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to delete cockpit source: %w", err)
+			}
+		}
+	} else {
+		listProjects, err := accountAPI.ListProjects(&accountSDK.ProjectAPIListProjectsRequest{}, scw.WithAllPages())
+		if err != nil {
+			return fmt.Errorf("failed to list projects: %w", err)
+		}
+
+		for _, project := range listProjects.Projects {
+			if !strings.HasPrefix(project.Name, "tf_tests") {
+				continue
+			}
+
+			listDatasources, err := cockpitAPI.ListDataSources(&cockpit.RegionalAPIListDataSourcesRequest{
+				ProjectID: project.ID,
+				Region:    region,
+			}, scw.WithAllPages())
+			if err != nil {
+				return fmt.Errorf("failed to list sources: %w", err)
+			}
+
+			for _, datsource := range listDatasources.DataSources {
+				err = cockpitAPI.DeleteDataSource(&cockpit.RegionalAPIDeleteDataSourceRequest{
+					DataSourceID: datsource.ID,
+					Region:       region,
+				})
+				if err != nil {
+					return fmt.Errorf("failed to delete cockpit source: %w", err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func SweepAllLocalities(scwClient *scw.Client, projectScoped bool) error {
+	for _, region := range (&cockpit.RegionalAPI{}).Regions() {
+		if err := SweepToken(scwClient, region, projectScoped); err != nil {
+			return err
+		}
+	}
+	if err := SweepGrafanaUser(scwClient, projectScoped); err != nil {
 		return err
 	}
 	for _, region := range (&cockpit.RegionalAPI{}).Regions() {
-		if err := SweepSource(scwClient, region); err != nil {
+		if err := SweepSource(scwClient, region, projectScoped); err != nil {
 			return err
 		}
 	}

--- a/api/ipam/v1/sweepers/sweepers.go
+++ b/api/ipam/v1/sweepers/sweepers.go
@@ -8,12 +8,20 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 
-func SweepIP(scwClient *scw.Client, region scw.Region) error {
+func SweepIP(scwClient *scw.Client, region scw.Region, projectScoped bool) error {
 	ipamAPI := ipam.NewAPI(scwClient)
 
 	logger.Warningf("sweeper: deleting the IPs in (%s)", region)
+	defaultProjectID, exists := scwClient.GetDefaultProjectID()
+	var projectID *string = nil
+	if projectScoped && (!exists || (defaultProjectID == "")) {
+		return fmt.Errorf("failed to get the default project id for a project scoped sweep")
+	}
+	if projectScoped {
+		projectID = &defaultProjectID
+	}
 
-	listIPs, err := ipamAPI.ListIPs(&ipam.ListIPsRequest{Region: region}, scw.WithAllPages())
+	listIPs, err := ipamAPI.ListIPs(&ipam.ListIPsRequest{Region: region, ProjectID: projectID}, scw.WithAllPages())
 	if err != nil {
 		return fmt.Errorf("error listing ips in (%s) in sweeper: %s", region, err)
 	}
@@ -31,9 +39,9 @@ func SweepIP(scwClient *scw.Client, region scw.Region) error {
 	return nil
 }
 
-func SweepAllLocalities(scwClient *scw.Client) error {
+func SweepAllLocalities(scwClient *scw.Client, projectScoped bool) error {
 	for _, region := range (&ipam.API{}).Regions() {
-		err := SweepIP(scwClient, region)
+		err := SweepIP(scwClient, region, projectScoped)
 		if err != nil {
 			return err
 		}

--- a/api/k8s/v1/sweepers/sweepers.go
+++ b/api/k8s/v1/sweepers/sweepers.go
@@ -8,11 +8,18 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 
-func SweepCluster(scwClient *scw.Client, region scw.Region) error {
+func SweepCluster(scwClient *scw.Client, region scw.Region, projectScoped bool) error {
 	k8sAPI := k8s.NewAPI(scwClient)
-
 	logger.Warningf("sweeper: destroying the k8s cluster in (%s)", region)
-	listClusters, err := k8sAPI.ListClusters(&k8s.ListClustersRequest{Region: region}, scw.WithAllPages())
+	defaultProjectID, exists := scwClient.GetDefaultProjectID()
+	var projectID *string = nil
+	if projectScoped && (!exists || (defaultProjectID == "")) {
+		return fmt.Errorf("failed to get the default project id for a project scoped sweep")
+	}
+	if projectScoped {
+		projectID = &defaultProjectID
+	}
+	listClusters, err := k8sAPI.ListClusters(&k8s.ListClustersRequest{Region: region, ProjectID: projectID}, scw.WithAllPages())
 	if err != nil {
 		return fmt.Errorf("error listing clusters in (%s) in sweeper: %s", region, err)
 	}
@@ -49,9 +56,9 @@ func SweepCluster(scwClient *scw.Client, region scw.Region) error {
 	return nil
 }
 
-func SweepAllLocalities(scwClient *scw.Client) error {
+func SweepAllLocalities(scwClient *scw.Client, projectScoped bool) error {
 	for _, region := range (&k8s.API{}).Regions() {
-		err := SweepCluster(scwClient, region)
+		err := SweepCluster(scwClient, region, projectScoped)
 		if err != nil {
 			return err
 		}

--- a/api/mongodb/v1alpha1/sweepers/sweepers.go
+++ b/api/mongodb/v1alpha1/sweepers/sweepers.go
@@ -8,12 +8,22 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 
-func SweepSnapshots(scwClient *scw.Client, region scw.Region) error {
+func SweepSnapshots(scwClient *scw.Client, region scw.Region, projectScoped bool) error {
 	mongodbAPI := mongodb.NewAPI(scwClient)
 	logger.Warningf("sweeper: destroying mongodb snapshots in (%s)", region)
 
+	defaultProjectID, exists := scwClient.GetDefaultProjectID()
+	var projectID *string = nil
+	if projectScoped && (!exists || (defaultProjectID == "")) {
+		return fmt.Errorf("failed to get the default project id for a project scoped sweep")
+	}
+	if projectScoped {
+		projectID = &defaultProjectID
+	}
+
 	listSnapshots, err := mongodbAPI.ListSnapshots(&mongodb.ListSnapshotsRequest{
-		Region: region,
+		Region:    region,
+		ProjectID: projectID,
 	}, scw.WithAllPages())
 	if err != nil {
 		return fmt.Errorf("error listing mongodb snapshots in (%s) in sweeper: %w", region, err)
@@ -32,11 +42,20 @@ func SweepSnapshots(scwClient *scw.Client, region scw.Region) error {
 	return nil
 }
 
-func SweepInstances(scwClient *scw.Client, region scw.Region) error {
+func SweepInstances(scwClient *scw.Client, region scw.Region, projectScoped bool) error {
 	mongodbAPI := mongodb.NewAPI(scwClient)
 	logger.Warningf("sweeper: destroying the mongodb instance in (%s)", region)
+	defaultProjectID, exists := scwClient.GetDefaultProjectID()
+	var projectID *string = nil
+	if projectScoped && (!exists || (defaultProjectID == "")) {
+		return fmt.Errorf("failed to get the default project id for a project scoped sweep")
+	}
+	if projectScoped {
+		projectID = &defaultProjectID
+	}
 	listInstance, err := mongodbAPI.ListInstances(&mongodb.ListInstancesRequest{
-		Region: region,
+		Region:    region,
+		ProjectID: projectID,
 	})
 	if err != nil {
 		return fmt.Errorf("error listing mongodb instance in (%s) in sweeper: %w", region, err)
@@ -55,13 +74,13 @@ func SweepInstances(scwClient *scw.Client, region scw.Region) error {
 	return nil
 }
 
-func SweepAllLocalities(scwClient *scw.Client) error {
+func SweepAllLocalities(scwClient *scw.Client, projectScoped bool) error {
 	for _, region := range (&mongodb.API{}).Regions() {
-		err := SweepSnapshots(scwClient, region)
+		err := SweepSnapshots(scwClient, region, projectScoped)
 		if err != nil {
 			return err
 		}
-		err = SweepInstances(scwClient, region)
+		err = SweepInstances(scwClient, region, projectScoped)
 		if err != nil {
 			return err
 		}

--- a/api/rdb/v1/sweepers/sweepers.go
+++ b/api/rdb/v1/sweepers/sweepers.go
@@ -8,12 +8,21 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 
-func SweepBackups(scwClient *scw.Client, region scw.Region) error {
+func SweepBackups(scwClient *scw.Client, region scw.Region, projectScoped bool) error {
 	rdbAPI := rdb.NewAPI(scwClient)
 	logger.Warningf("sweeper: destroying rdb backups in (%s)", region)
+	defaultProjectID, exists := scwClient.GetDefaultProjectID()
+	var projectID *string = nil
+	if projectScoped && (!exists || (defaultProjectID == "")) {
+		return fmt.Errorf("failed to get the default project id for a project scoped sweep")
+	}
+	if projectScoped {
+		projectID = &defaultProjectID
+	}
 
 	listBackups, err := rdbAPI.ListDatabaseBackups(&rdb.ListDatabaseBackupsRequest{
-		Region: region,
+		Region:    region,
+		ProjectID: projectID,
 	}, scw.WithAllPages())
 	if err != nil {
 		return fmt.Errorf("error listing rdb backups in (%s) in sweeper: %s", region, err)
@@ -32,11 +41,20 @@ func SweepBackups(scwClient *scw.Client, region scw.Region) error {
 	return nil
 }
 
-func SweepInstance(scwClient *scw.Client, region scw.Region) error {
+func SweepInstance(scwClient *scw.Client, region scw.Region, projectScoped bool) error {
 	rdbAPI := rdb.NewAPI(scwClient)
 	logger.Warningf("sweeper: destroying the rdb instance in (%s)", region)
+	defaultProjectID, exists := scwClient.GetDefaultProjectID()
+	var projectID *string = nil
+	if projectScoped && (!exists || (defaultProjectID == "")) {
+		return fmt.Errorf("failed to get the default project id for a project scoped sweep")
+	}
+	if projectScoped {
+		projectID = &defaultProjectID
+	}
 	listInstances, err := rdbAPI.ListInstances(&rdb.ListInstancesRequest{
-		Region: region,
+		Region:    region,
+		ProjectID: projectID,
 	}, scw.WithAllPages())
 	if err != nil {
 		return fmt.Errorf("error listing rdb instances in (%s) in sweeper: %s", region, err)
@@ -55,13 +73,13 @@ func SweepInstance(scwClient *scw.Client, region scw.Region) error {
 	return nil
 }
 
-func SweepAllLocalities(scwClient *scw.Client) error {
+func SweepAllLocalities(scwClient *scw.Client, projectScoped bool) error {
 	for _, region := range (&rdb.API{}).Regions() {
-		err := SweepBackups(scwClient, region)
+		err := SweepBackups(scwClient, region, projectScoped)
 		if err != nil {
 			return err
 		}
-		err = SweepInstance(scwClient, region)
+		err = SweepInstance(scwClient, region, projectScoped)
 		if err != nil {
 			return err
 		}

--- a/api/serverless_sqldb/v1alpha1/sweepers/sweepers.go
+++ b/api/serverless_sqldb/v1alpha1/sweepers/sweepers.go
@@ -8,12 +8,21 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 
-func SweepDatabase(scwClient *scw.Client, region scw.Region) error {
+func SweepDatabase(scwClient *scw.Client, region scw.Region, projectScoped bool) error {
 	sdbAPI := sdbSDK.NewAPI(scwClient)
 	logger.Warningf("sweeper: destroying the serverless sql database in (%s)", region)
+	defaultProjectID, exists := scwClient.GetDefaultProjectID()
+	projectID := ""
+	if projectScoped && (!exists || (defaultProjectID == "")) {
+		return fmt.Errorf("failed to get the default project id for a project scoped sweep")
+	}
+	if projectScoped {
+		projectID = defaultProjectID
+	}
 	listServerlessSQLDBDatabases, err := sdbAPI.ListDatabases(
 		&sdbSDK.ListDatabasesRequest{
-			Region: region,
+			Region:    region,
+			ProjectID: projectID,
 		}, scw.WithAllPages())
 	if err != nil {
 		return fmt.Errorf("error listing database in (%s) in sweeper: %s", region, err)
@@ -32,9 +41,9 @@ func SweepDatabase(scwClient *scw.Client, region scw.Region) error {
 	return nil
 }
 
-func SweepAllLocalities(scwClient *scw.Client) error {
+func SweepAllLocalities(scwClient *scw.Client, projectScoped bool) error {
 	for _, region := range (&sdbSDK.API{}).Regions() {
-		err := SweepDatabase(scwClient, region)
+		err := SweepDatabase(scwClient, region, projectScoped)
 		if err != nil {
 			return err
 		}

--- a/cmd/sdk-sweeper/main.go
+++ b/cmd/sdk-sweeper/main.go
@@ -45,12 +45,12 @@ func mainNoExit() int {
 
 	errs := []error(nil)
 
-	err = containerSweeper.SweepAllLocalities(client)
+	err = containerSweeper.SweepAllLocalities(client, false)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("error sweeping container: %w", err))
 	}
 
-	err = instanceSweeper.SweepAllLocalities(client)
+	err = instanceSweeper.SweepAllLocalities(client, false)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("error sweeping instance: %w", err))
 	}


### PR DESCRIPTION
# The feature

- Allow user to scope the e2e sweepers to the default project id only and not every project in the organization

# Implementation

- Use a flag `projectScoped` that change the function behavior when set to `true`.  
- Functions will only target the `SCW_DEFAULT_PROJECT_ID` passed instead of all projects in the organization
- For some sweepers we need to make a first call that list the resources to target in the project (like crons in functions)