### PR TITLE
feat(jobs): add sweepers and waiters for v1alpha2

### DIFF
--- a/api/jobs/v1alpha2/custom_job_run.go
+++ b/api/jobs/v1alpha2/custom_job_run.go
@@ -1,0 +1,62 @@
+package jobs
+
+import (
+	"time"
+
+	"github.com/scaleway/scaleway-sdk-go/errors"
+	"github.com/scaleway/scaleway-sdk-go/internal/async"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+const (
+	defaultRetryInterval = 15 * time.Second
+	defaultTimeout       = 15 * time.Minute
+)
+
+type WaitForJobRunRequest struct {
+	JobRunID      string
+	Region        scw.Region
+	Timeout       *time.Duration
+	RetryInterval *time.Duration
+}
+
+// WaitForJobRun waits for the job run to be in a "terminal state" before returning.
+// This function can be used to wait for a job run to fail for example.
+func (s *API) WaitForJobRun(req *WaitForJobRunRequest, opts ...scw.RequestOption) (*JobRun, error) {
+	timeout := defaultTimeout
+	if req.Timeout != nil {
+		timeout = *req.Timeout
+	}
+	retryInterval := defaultRetryInterval
+	if req.RetryInterval != nil {
+		retryInterval = *req.RetryInterval
+	}
+
+	terminalStatus := map[JobRunState]struct{}{
+		JobRunStateSucceeded:   {},
+		JobRunStateFailed:      {},
+		JobRunStateInterrupted: {},
+	}
+
+	jobRun, err := async.WaitSync(&async.WaitSyncConfig{
+		Get: func() (any, bool, error) {
+			res, err := s.GetJobRun(&GetJobRunRequest{
+				JobRunID: req.JobRunID,
+				Region:   req.Region,
+			}, opts...)
+			if err != nil {
+				return nil, false, err
+			}
+			_, isTerminal := terminalStatus[res.State]
+
+			return res, isTerminal, nil
+		},
+		Timeout:          timeout,
+		IntervalStrategy: async.LinearIntervalStrategy(retryInterval),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "waiting for job run failed")
+	}
+
+	return jobRun.(*JobRun), nil
+}

--- a/api/jobs/v1alpha2/sweepers/sweepers.go
+++ b/api/jobs/v1alpha2/sweepers/sweepers.go
@@ -1,0 +1,53 @@
+package sweepers
+
+import (
+	"fmt"
+
+	jobs "github.com/scaleway/scaleway-sdk-go/api/jobs/v1alpha2"
+	"github.com/scaleway/scaleway-sdk-go/logger"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+func SweepJobDefinition(scwClient *scw.Client, region scw.Region, projectScoped bool) error {
+	jobsAPI := jobs.NewAPI(scwClient)
+	logger.Warningf("sweeper: destroying the jobs definitions in (%s)", region)
+	defaultProjectID, exists := scwClient.GetDefaultProjectID()
+	var projectID *string = nil
+	if projectScoped && (!exists || (defaultProjectID == "")) {
+		return fmt.Errorf("failed to get the default project id for a project scoped sweep")
+	}
+	if projectScoped {
+		projectID = &defaultProjectID
+	}
+	listJobDefinitions, err := jobsAPI.ListJobDefinitions(
+		&jobs.ListJobDefinitionsRequest{
+			Region:    region,
+			ProjectID: projectID,
+		}, scw.WithAllPages())
+	if err != nil {
+		return fmt.Errorf("error listing definition in (%s) in sweeper: %s", region, err)
+	}
+
+	for _, definition := range listJobDefinitions.JobDefinitions {
+		err := jobsAPI.DeleteJobDefinition(&jobs.DeleteJobDefinitionRequest{
+			JobDefinitionID: definition.ID,
+			Region:          region,
+		})
+		if err != nil {
+			return fmt.Errorf("error deleting definition in sweeper: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func SweepAllLocalities(scwClient *scw.Client, projectScoped bool) error {
+	for _, region := range (&jobs.API{}).Regions() {
+		err := SweepJobDefinition(scwClient, region, projectScoped)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR copies the custom sweeper and waiter functions from v1alpha1 to v1alpha2 for serverless jobs.