### PR TITLE
fix(dedibox): Force pdf download in raw format

### DIFF
--- a/api/dedibox/v1/dedibox_sdk.go
+++ b/api/dedibox/v1/dedibox_sdk.go
@@ -7772,7 +7772,7 @@ func (s *BillingAPI) DownloadInvoice(req *BillingAPIDownloadInvoiceRequest, opts
 
 	scwReq := &scw.ScalewayRequest{
 		Method: "GET",
-		Path:   "/dedibox/v1/invoices/" + fmt.Sprint(req.InvoiceID) + "/download",
+		Path:   "/dedibox/v1/invoices/" + fmt.Sprint(req.InvoiceID) + "/download?dl=1",
 	}
 
 	var resp scw.File


### PR DESCRIPTION
By default, the file is inlined. However, this causes an issue with PDF files, as it conflicts with JSON encoding and leads to a “Malformed UTF-8 characters” error.