### PR TITLE
fix(locality): add support for zone `multi-az` value

### DIFF
--- a/scw/locality.go
+++ b/scw/locality.go
@@ -37,6 +37,8 @@ const (
 	ZonePlWaw3 = Zone("pl-waw-3")
 	// ZoneItMil1 represents the it-mil-1 zone
 	ZoneItMil1 = Zone("it-mil-1")
+	// ZoneMultiAZ represents multi-az (multiple zones)
+	ZoneMultiAZ = Zone("multi-az")
 )
 
 // AllZones is an array that list all zones
@@ -138,6 +140,9 @@ func ParseZone(zone string) (Zone, error) {
 		// would be triggered by API market place
 		// logger.Warningf("ams1 is a deprecated name for zone, use nl-ams-1 instead")
 		return ZoneNlAms1, nil
+	case ZoneMultiAZ.String():
+		// would be triggered by API environmental footprint
+		return ZoneMultiAZ, nil
 	default:
 		if !validation.IsZone(zone) {
 			zones := []string(nil)


### PR DESCRIPTION
`scw environmental-footprint data get` CLI call breaks in the sdk go unmarshalling, because the API sets the zone as `multi-az` for regional products, causing the following error : `scaleway-sdk-go: could not parse application/json response body: scaleway-sdk-go: bad zone format, available zones are: fr-par-1, fr-par-2, fr-par-3, nl-ams-1, nl-ams-2, nl-ams-3, pl-waw-1, pl-waw-2, pl-waw-3, it-mil-1`. 