### PR TITLE
feat(vcr): add fields to QueryMatcherIgnore for container logs tests

### DIFF
--- a/vcr/matchers.go
+++ b/vcr/matchers.go
@@ -24,6 +24,9 @@ const (
 // QueryMatcherIgnore contains the list of query value that should be ignored when matching requests with cassettes
 var QueryMatcherIgnore = []string{
 	"organization_id",
+	"project_id",
+	"start",
+	"end",
 }
 
 func customDockerMatcher(r *http.Request, i cassette.Request) bool {


### PR DESCRIPTION
This PR adds `project_id`, `start` and `end` to the list of fields to ignore when matching queries in URLs.

Needed by [scaleway-cli#5469](https://github.com/scaleway/scaleway-cli/pull/5469)