### PR TITLE
chore(vcr): add unescapeDockerURL hook for container deploy tests

### DIFF
--- a/vcr/matchers.go
+++ b/vcr/matchers.go
@@ -38,6 +38,15 @@ func customDockerMatcher(r *http.Request, i cassette.Request) bool {
 	return r.URL.String() == escapedRecordedURL
 }
 
+func unescapeDockerURL(i *cassette.Interaction) error {
+	i.Request.URL = regexp.MustCompile(`http://`+escapedUnixDockerEngine+`(.+)?`).
+		ReplaceAllString(
+			i.Request.URL,
+			"http://"+unixDockerEngine+"${1}")
+
+	return nil
+}
+
 func customS3BodyMatcher(r *http.Request, i cassette.Request) bool {
 	reqBody, err := r.GetBody()
 	if err != nil {

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -83,6 +83,9 @@ func NewHTTPRecorder(t *testing.T, pkgFolder string, update bool, realTransport 
 	recorderOptions := []recorder.Option{
 		// Ignore requests durations when replaying cassettes
 		recorder.WithSkipRequestLatency(true),
+		// Starting with v3, go-vcr now calls net/url.Parse to build the interaction which results in an error for escaped
+		// Docker URLs on Test_Deploy (container), so we need to unescape these paths on this step.
+		recorder.WithHook(unescapeDockerURL, recorder.AfterCaptureHook),
 		// Remove information that is either sensitive or that would disrupt matching from the request
 		recorder.WithHook(cassetteRequestFilter, recorder.BeforeSaveHook),
 		// Remove secrets and unnecessary information from the response


### PR DESCRIPTION
Needed for [scaleway-cli#5580](https://github.com/scaleway/scaleway-cli/pull/5580)