### PR TITLE
feat(vcr): normalize buildpacks-related data for container deploy tests

### DIFF
--- a/vcr/matchers.go
+++ b/vcr/matchers.go
@@ -30,12 +30,21 @@ var QueryMatcherIgnore = []string{
 }
 
 func customDockerMatcher(r *http.Request, i cassette.Request) bool {
+	// URL is stored unescaped for human readability, but will be escaped in request
 	escapedRecordedURL := regexp.MustCompile(`http://`+unixDockerEngine+`(.+)?`).
 		ReplaceAllString(
 			i.URL,
 			"http://"+escapedUnixDockerEngine+"${1}")
 
-	return r.URL.String() == escapedRecordedURL
+	// Buildpacks
+	// URL is stored normalized on the cassette, so we need to normalize the request to compare them
+	normalizedRequestURL := r.URL.String()
+	normalizedRequestURL = regexp.MustCompile(`pack\.local/builder/[0-9a-f]{20}`).
+		ReplaceAllString(normalizedRequestURL, "pack.local/builder/11111111111111111111")
+	normalizedRequestURL = regexp.MustCompile(`pack\.local%2Fbuilder%2F[0-9a-f]{20}`).
+		ReplaceAllString(normalizedRequestURL, "pack.local%2Fbuilder%2F11111111111111111111")
+
+	return normalizedRequestURL == escapedRecordedURL
 }
 
 func unescapeDockerURL(i *cassette.Interaction) error {

--- a/vcr/vcr.go
+++ b/vcr/vcr.go
@@ -51,6 +51,14 @@ func cassetteRequestFilter(i *cassette.Interaction) error {
 			i.Request.URL,
 			"${1}SCWXXXXXXXXXXXXXXXXX${2}")
 
+	// Buildpacks
+	i.Request.URL = regexp.MustCompile(`pack\.local%2Fbuilder%2F[0-9a-f]{20}`).
+		ReplaceAllString(i.Request.URL, "pack.local%2Fbuilder%2F11111111111111111111")
+	i.Request.URL = regexp.MustCompile(`pack\.local/builder/[0-9a-f]{20}`).
+		ReplaceAllString(i.Request.URL, "pack.local/builder/11111111111111111111")
+	i.Request.Body = regexp.MustCompile(`pack\.local/builder/[0-9a-f]{20}`).
+		ReplaceAllString(i.Request.Body, "pack.local/builder/11111111111111111111")
+
 	return nil
 }
 
@@ -62,6 +70,10 @@ func cassetteResponseFilter(i *cassette.Interaction) error {
 
 	i.Response.Body = regexp.MustCompile(`"secret_key":"[0-9a-f-]{36}"`).
 		ReplaceAllString(i.Response.Body, `"secret_key":"11111111-1111-1111-1111-111111111111"`)
+
+	// Buildpacks
+	i.Response.Body = regexp.MustCompile(`pack\.local/builder/[0-9a-f]{20}`).
+		ReplaceAllString(i.Response.Body, "pack.local/builder/11111111111111111111")
 
 	return nil
 }


### PR DESCRIPTION
In the CLI test `Test_Deploy/Buildpack` from the container package, we need to normalize buildpacks IDs in the URLs of both the request and the cassette for them to match.

Needed for [scaleway-cli#5580](https://github.com/scaleway/scaleway-cli/pull/5580)