### PR TITLE
feat(client): retrieve the API Gateway metadata

### DIFF
--- a/scw/client.go
+++ b/scw/client.go
@@ -28,6 +28,7 @@ type Client struct {
 	httpClient            httpClient
 	auth                  auth.Auth
 	apiURL                string
+	apiMetadata           ApiMetadata
 	s3Endpoint            string
 	userAgent             string
 	defaultOrganizationID *string
@@ -35,6 +36,12 @@ type Client struct {
 	defaultRegion         *Region
 	defaultZone           *Zone
 	defaultPageSize       *uint32
+}
+
+type ApiMetadata struct {
+	Platform  string
+	Partition string
+	Domain    string
 }
 
 func defaultOptions() []ClientOption {
@@ -97,6 +104,27 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 		defaultZone:           s.defaultZone,
 		defaultPageSize:       s.defaultPageSize,
 	}, nil
+}
+
+// GetAPIMetadata returns the API metadata exposed by the API
+// Gateway. This metadata holds information on the platform,
+// the partition and the domain on which the Scaleway cloud is
+// running.
+func (c *Client) GetAPIMetadata() (ApiMetadata, error) {
+	if c.apiMetadata != (ApiMetadata{}) {
+		return c.apiMetadata, nil
+	}
+
+	scwReq := &ScalewayRequest{
+		Method: "GET",
+		Path:   "/metadata",
+	}
+
+	err := c.Do(scwReq, &c.apiMetadata)
+	if err != nil {
+		return ApiMetadata{}, errors.Wrap(err, "could request api metadata")
+	}
+	return c.apiMetadata, nil
 }
 
 // GetDefaultOrganizationID returns the default organization ID

--- a/scw/client_test.go
+++ b/scw/client_test.go
@@ -336,3 +336,25 @@ func TestNewVariableFromType(t *testing.T) {
 
 	testhelpers.Equals(t, &fakeType{}, newVariableFromType(&fakeType{3}))
 }
+
+func TestClientGetAPIMetadata(t *testing.T) {
+	t.Run("APIMetadata", func(t *testing.T) {
+		client, err := NewClient()
+		testhelpers.AssertNoError(t, err)
+
+		metadata, err := client.GetAPIMetadata()
+		testhelpers.AssertNoError(t, err)
+		testhelpers.Equals(t, "scw.eu", metadata.Domain)
+		testhelpers.Equals(t, "scw", metadata.Partition)
+		testhelpers.Equals(t, "external", metadata.Platform)
+
+		// let's make sure the client cannot call home anymore
+		// (in fact, if it tries to use httpClient, it will panic)
+		client.httpClient = nil
+		metadata, err = client.GetAPIMetadata()
+		testhelpers.AssertNoError(t, err)
+		testhelpers.Equals(t, "scw.eu", metadata.Domain)
+		testhelpers.Equals(t, "scw", metadata.Partition)
+		testhelpers.Equals(t, "external", metadata.Platform)
+	})
+}


### PR DESCRIPTION
This commit adds support for retrieving the API Gateway's metadata available at (e.g.) https://api.scaleway.com/metadata.

The metadata is retrieved once, only as needed. It is then cached and the values are reused.

This paves the way for removing the hardcoded value set before the various setSRN(platform) calls.