### PR TITLE
feat: add fr-snc region and zones

### DIFF
--- a/scw/client_option_test.go
+++ b/scw/client_option_test.go
@@ -126,7 +126,7 @@ func TestClientOptions(t *testing.T) {
 				s.token = auth.NewToken(testAccessKey, testSecretKey)
 				s.defaultRegion = &v
 			},
-			errStr: "scaleway-sdk-go: invalid default region format 'invalid', available regions are: fr-par, nl-ams, pl-waw, it-mil",
+			errStr: "scaleway-sdk-go: invalid default region format 'invalid', available regions are: fr-par, fr-snc, nl-ams, pl-waw, it-mil",
 		},
 		{
 			name: "Should throw a zone error",
@@ -144,7 +144,7 @@ func TestClientOptions(t *testing.T) {
 				s.token = auth.NewToken(testAccessKey, testSecretKey)
 				s.defaultZone = &v
 			},
-			errStr: "scaleway-sdk-go: invalid default zone format 'invalid', available zones are: fr-par-1, fr-par-2, fr-par-3, nl-ams-1, nl-ams-2, nl-ams-3, pl-waw-1, pl-waw-2, pl-waw-3, it-mil-1",
+			errStr: "scaleway-sdk-go: invalid default zone format 'invalid', available zones are: fr-par-1, fr-par-2, fr-par-3, fr-snc-1, fr-snc-2, fr-snc-3, nl-ams-1, nl-ams-2, nl-ams-3, pl-waw-1, pl-waw-2, pl-waw-3, it-mil-1",
 		},
 	}
 

--- a/scw/locality.go
+++ b/scw/locality.go
@@ -3,6 +3,7 @@ package scw
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/scaleway/scaleway-sdk-go/errors"
@@ -23,6 +24,12 @@ const (
 	ZoneFrPar2 = Zone("fr-par-2")
 	// ZoneFrPar3 represents the fr-par-3 zone
 	ZoneFrPar3 = Zone("fr-par-3")
+	// ZoneFrSnc1 represents the fr-snc-1 zone
+	ZoneFrSnc1 = Zone("fr-snc-1")
+	// ZoneFrSnc2 represents the fr-snc-2 zone
+	ZoneFrSnc2 = Zone("fr-snc-2")
+	// ZoneFrSnc3 represents the fr-snc-3 zone
+	ZoneFrSnc3 = Zone("fr-snc-3")
 	// ZoneNlAms1 represents the nl-ams-1 zone
 	ZoneNlAms1 = Zone("nl-ams-1")
 	// ZoneNlAms2 represents the nl-ams-2 zone
@@ -44,6 +51,9 @@ var AllZones = []Zone{
 	ZoneFrPar1,
 	ZoneFrPar2,
 	ZoneFrPar3,
+	ZoneFrSnc1,
+	ZoneFrSnc2,
+	ZoneFrSnc3,
 	ZoneNlAms1,
 	ZoneNlAms2,
 	ZoneNlAms3,
@@ -85,6 +95,8 @@ type Region string
 const (
 	// RegionFrPar represents the fr-par region
 	RegionFrPar = Region("fr-par")
+	// RegionFrSnc represents the fr-snc region
+	RegionFrSnc = Region("fr-snc")
 	// RegionNlAms represents the nl-ams region
 	RegionNlAms = Region("nl-ams")
 	// RegionPlWaw represents the pl-waw region
@@ -96,6 +108,7 @@ const (
 // AllRegions is an array that list all regions
 var AllRegions = []Region{
 	RegionFrPar,
+	RegionFrSnc,
 	RegionNlAms,
 	RegionPlWaw,
 	RegionItMil,
@@ -103,12 +116,7 @@ var AllRegions = []Region{
 
 // Exists checks whether a region exists
 func (region Region) Exists() bool {
-	for _, r := range AllRegions {
-		if r == region {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(AllRegions, region)
 }
 
 // GetZones is a function that returns the zones for the specified region
@@ -116,6 +124,8 @@ func (region Region) GetZones() []Zone {
 	switch region {
 	case RegionFrPar:
 		return []Zone{ZoneFrPar1, ZoneFrPar2, ZoneFrPar3}
+	case RegionFrSnc:
+		return []Zone{ZoneFrSnc1, ZoneFrSnc2, ZoneFrSnc3}
 	case RegionNlAms:
 		return []Zone{ZoneNlAms1, ZoneNlAms2, ZoneNlAms3}
 	case RegionPlWaw:

--- a/scw/locality.go
+++ b/scw/locality.go
@@ -65,12 +65,7 @@ var AllZones = []Zone{
 
 // Exists checks whether a zone exists
 func (zone Zone) Exists() bool {
-	for _, z := range AllZones {
-		if z == zone {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(AllZones, zone)
 }
 
 // String returns a Zone as a string

--- a/scw/locality_test.go
+++ b/scw/locality_test.go
@@ -57,17 +57,17 @@ func TestParseZone(t *testing.T) {
 		{
 			input:    "fr-par",
 			expected: "",
-			err:      errors.New("bad zone format, available zones are: fr-par-1, fr-par-2, fr-par-3, nl-ams-1, nl-ams-2, nl-ams-3, pl-waw-1, pl-waw-2, pl-waw-3, it-mil-1"),
+			err:      errors.New("bad zone format, available zones are: fr-par-1, fr-par-2, fr-par-3, fr-snc-1, fr-snc-2, fr-snc-3, nl-ams-1, nl-ams-2, nl-ams-3, pl-waw-1, pl-waw-2, pl-waw-3, it-mil-1"),
 		},
 		{
 			input:    "fr-par-n",
 			expected: "",
-			err:      errors.New("bad zone format, available zones are: fr-par-1, fr-par-2, fr-par-3, nl-ams-1, nl-ams-2, nl-ams-3, pl-waw-1, pl-waw-2, pl-waw-3, it-mil-1"),
+			err:      errors.New("bad zone format, available zones are: fr-par-1, fr-par-2, fr-par-3, fr-snc-1, fr-snc-2, fr-snc-3, nl-ams-1, nl-ams-2, nl-ams-3, pl-waw-1, pl-waw-2, pl-waw-3, it-mil-1"),
 		},
 		{
 			input:    "fr-par-200",
 			expected: "",
-			err:      errors.New("bad zone format, available zones are: fr-par-1, fr-par-2, fr-par-3, nl-ams-1, nl-ams-2, nl-ams-3, pl-waw-1, pl-waw-2, pl-waw-3, it-mil-1"),
+			err:      errors.New("bad zone format, available zones are: fr-par-1, fr-par-2, fr-par-3, fr-snc-1, fr-snc-2, fr-snc-3, nl-ams-1, nl-ams-2, nl-ams-3, pl-waw-1, pl-waw-2, pl-waw-3, it-mil-1"),
 		},
 	}
 
@@ -131,12 +131,12 @@ func TestParseRegion(t *testing.T) {
 		{
 			input:    "fr-par-1",
 			expected: "",
-			err:      errors.New("bad region format, available regions are: fr-par, nl-ams, pl-waw, it-mil"),
+			err:      errors.New("bad region format, available regions are: fr-par, fr-snc, nl-ams, pl-waw, it-mil"),
 		},
 		{
 			input:    "fr-pa1",
 			expected: "",
-			err:      errors.New("bad region format, available regions are: fr-par, nl-ams, pl-waw, it-mil"),
+			err:      errors.New("bad region format, available regions are: fr-par, fr-snc, nl-ams, pl-waw, it-mil"),
 		},
 	}
 


### PR DESCRIPTION
Fixes the following warning when using `fr-snc` with our Terraform provider

```
Warning: expected region to be one of ["fr-par" "nl-ams" "pl-waw" "it-mil"], got fr-snc
```